### PR TITLE
chore: Vercel 배포하기

### DIFF
--- a/.github/workflows/sync-upsteam.yml
+++ b/.github/workflows/sync-upsteam.yml
@@ -2,8 +2,8 @@ name: Sync Fork with Public Upstream
 
 on:
   schedule:
-    # 예: 매일 한국 시간 오전 9시 (UTC 00:00) 실행
-    - cron: '0 5 * * *'
+    # 예: 매일 한국 시간 오전 0시 실행
+    - cron: '0 15 * * *'
   workflow_dispatch: # 테스트용 수동 실행 버튼
 
 jobs:


### PR DESCRIPTION
## ✨ PR 개요
oz_externship_fe_06_team1 에서 개발하는 프로젝트에 배포 기능을 추가 위해 .github/workflows/sync-upsteam.yml 를 추가

## 📌 관련 이슈
Closes #1 

## 🧩 작업 내용 (주요 변경사항)
- .github/workflows/sync-upsteam.yml 추가

## 💬 리뷰 포인트
1. 시간 수정
```
on:
  schedule:
    - cron: '0 15 * * *' 
  workflow_dispatch:

```
0 -> 0분 , 15 -> 15시(UTC 기준, 한국으로 0시 하기 위해 설정 24 - 9 = 15), * * * -> 매일

2. remote 레포 연결
```
      - name: Add Upstream Remote (Public)
        # Public이므로 토큰 없이 https 주소만 있으면 됩니다. (조직 레포)
        run: |
          git remote add upstream https://github.com/OZ-Coding-School/oz_externship_fe_06_team1.git
          git fetch upstream
```

## 📸 스크린샷 
개인 레포지토리 https://github.com/hyunsik2000/oz_externship_fe_06_team1/actions/workflows/sync-upsteam.yml 에서 테스트
<img width="1915" height="572" alt="image" src="https://github.com/user-attachments/assets/64620a28-7a11-4cde-8725-cdd26834ff1f" />

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료