### PR TITLE
style: index.css에 기본 색상 팔레트 추가 (#8)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,26 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-primary-50: #f2effd;
+  --color-primary-300: #d7cbf7;
+  --color-primary-400: #b69cf1;
+  --color-primary-500: #986be9;
+  --color-primary-600: #7c35d9;
+  --color-primary-700: #522193;
+
+  --color-grey-50: #f7f7f7;
+  --color-grey-100: #f5f5f5;
+  --color-grey-300: #dddddd;
+  --color-grey-400: #a6a6a6;
+  --color-grey-600: #666666;
+  --color-grey-800: #222222;
+
+  --color-success-100: #e1f2e3;
+  --color-success-400: #5eb669;
+
+  --color-error-100: #f9e2e2;
+  --color-error-400: #cc0a0a;
+
+  --color-warning-100: #fdeece;
+  --color-warning-400: #f6a818;
+}


### PR DESCRIPTION
## ✨ PR 개요
<!-- 어떤 작업을 했는지 간략히 요약 -->
피그마에 명시된 기본 색상 팔레트를 `index.css` 파일에 추가

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #8 

## 🧩 작업 내용 (주요 변경사항)
- 메인 색상 팔레트는 `primary`, 회색 색상 팔레트는 기존 테일윈드 회색인 `gray`와 별개로 설정하기 위해 `grey` 키워드를 사용
- 커스텀 `alert` 모달 창에 쓰일 색들은 각자 `success`, `error`, `warning`으로 표기

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
<img width="843" height="357" alt="image" src="https://github.com/user-attachments/assets/33e8918d-4330-4493-b912-2dbde557d36a" />

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
