### PR TITLE
feat: 쪽지시험 상세 문제 수정 입력 폼 UI 제작 (#49)

### DIFF
--- a/src/components/detail-exam/DetailExamContainer.tsx
+++ b/src/components/detail-exam/DetailExamContainer.tsx
@@ -6,7 +6,7 @@ import DetailExamHeader from './DetailExamHeader'
 import {
   MOCK_EMPTY_QUESTION_LIST_RESPONSE,
   // MOCK_QUESTION_LIST_RESPONSE,
-} from '@/mocks/exam-data/QuestionList'
+} from '@/mocks/data/exam-data/QuestionList'
 
 export default function DetailExamContainer() {
   const [currentIndex, setCurrentIndex] = useState(0)

--- a/src/components/detail-exam/QuestionList.tsx
+++ b/src/components/detail-exam/QuestionList.tsx
@@ -1,4 +1,4 @@
-import type { QuestionListResponse } from '@/types/question'
+import type { QuestionListResponse, Question } from '@/types/question'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import type { Swiper as SwiperClass } from 'swiper'
 import {
@@ -12,6 +12,8 @@ import { Button } from '@/components/common/Button'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import 'swiper/css'
 import EmptyProblems from './problem/EmptyProblems'
+import { useState } from 'react'
+import ProblemModal from '@/components/detail-exam/AddProblemModal/ProblemModal'
 
 interface QuestionListProps {
   data: QuestionListResponse
@@ -32,75 +34,108 @@ export default function QuestionList({
 }: QuestionListProps) {
   const totalQuestions = data.questions.length
 
+  // 모달 상태 관리
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [modalMode, setModalMode] = useState<'create' | 'edit'>('create')
+  const [selectedQuestion, setSelectedQuestion] = useState<
+    Question | undefined
+  >(undefined)
+
+  // 문제 추가 모달 열기
+  const handleOpenAddModal = () => {
+    setModalMode('create')
+    setIsModalOpen(true)
+  }
+
+  // 문제 수정 모달 열기
+  const handleOpenEditModal = (question: Question) => {
+    setModalMode('edit')
+    setSelectedQuestion(question)
+    setIsModalOpen(true)
+  }
+
   if (totalQuestions === 0) {
     return <EmptyProblems />
   }
 
   return (
-    <div className="mx-auto flex items-center justify-center gap-10">
-      {/* 이전 버튼 */}
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={onPrev}
-        disabled={currentIndex === 0}
-        className="h-12 w-12 rounded-full border-transparent bg-transparent disabled:opacity-0"
-      >
-        <ChevronLeft className="text-grey-600 h-10 w-10" />
-      </Button>
-
-      {/* Swiper 컨테이너 */}
-      <div className="h-[600px] w-[1060px] overflow-hidden">
-        <Swiper
-          spaceBetween={50}
-          slidesPerView={1}
-          onSwiper={onSwiper}
-          onSlideChange={onSlideChange}
-          allowTouchMove={false}
-          className="h-full"
+    <>
+      <div className="mx-auto flex items-center justify-center gap-10">
+        {/* 이전 버튼 */}
+        <Button
+          size="icon"
+          onClick={onPrev}
+          disabled={currentIndex === 0}
+          className="h-12 w-12 rounded-full border-transparent bg-transparent disabled:opacity-0"
         >
-          {data.questions.map((question, i) => (
-            <SwiperSlide key={question.id}>
-              <div className="text-grey-800 flex h-full flex-col gap-2 rounded-xl border border-[#D9D9D9] bg-white p-7 font-semibold">
-                {/* 1. 문제 헤더 영역 */}
-                <ProblemHeader type={question.type} />
+          <ChevronLeft className="text-grey-600 h-10 w-10" />
+        </Button>
 
-                <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-3">
-                  {/* 2. 문제 제목 영역 */}
-                  <ProblemTitle
-                    index={i + 1}
-                    title={`${question.question} (${question.point}점)`}
-                  />
-
-                  {/* 3. 문제 정답 영역 */}
-                  <ProblemAnswer answer={question.correct_answer} />
-
-                  {/* 4. 문제 옵션 영역 */}
-                  <ProblemOption
+        {/* Swiper 컨테이너 */}
+        <div className="h-[600px] w-[1060px] overflow-hidden">
+          <Swiper
+            spaceBetween={50}
+            slidesPerView={1}
+            onSwiper={onSwiper}
+            onSlideChange={onSlideChange}
+            allowTouchMove={false}
+            className="h-full"
+          >
+            {data.questions.map((question, i) => (
+              <SwiperSlide key={question.id}>
+                <div className="text-grey-800 flex h-full flex-col gap-2 rounded-xl border border-[#D9D9D9] bg-white p-7 font-semibold">
+                  {/* 1. 문제 헤더 영역 */}
+                  <ProblemHeader
                     type={question.type}
-                    options={question.options}
-                    answer={question.correct_answer}
+                    onAdd={handleOpenAddModal}
+                    onEdit={() => handleOpenEditModal(question)}
+                    // onDelete={} 삭제 로직 필요 시 추가
                   />
 
-                  {/* 5. 문제 해설 영역 */}
-                  <ProblemExplain explain={question.explanation} />
+                  <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-3">
+                    {/* 2. 문제 제목 영역 */}
+                    <ProblemTitle
+                      index={i + 1}
+                      title={`${question.question} (${question.point}점)`}
+                    />
+
+                    {/* 3. 문제 정답 영역 */}
+                    <ProblemAnswer answer={question.correct_answer} />
+
+                    {/* 4. 문제 옵션 영역 */}
+                    <ProblemOption
+                      type={question.type}
+                      options={question.options}
+                      answer={question.correct_answer}
+                    />
+
+                    {/* 5. 문제 해설 영역 */}
+                    <ProblemExplain explain={question.explanation} />
+                  </div>
                 </div>
-              </div>
-            </SwiperSlide>
-          ))}
-        </Swiper>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </div>
+
+        {/* 다음 버튼 */}
+        <Button
+          size="icon"
+          onClick={onNext}
+          disabled={currentIndex === totalQuestions - 1}
+          className="h-12 w-12 rounded-full border-transparent bg-transparent disabled:opacity-0"
+        >
+          <ChevronRight className="text-grey-600 h-10 w-10" />
+        </Button>
       </div>
 
-      {/* 다음 버튼 */}
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={onNext}
-        disabled={currentIndex === totalQuestions - 1}
-        className="h-12 w-12 rounded-full border-transparent bg-transparent disabled:opacity-0"
-      >
-        <ChevronRight className="text-grey-600 h-10 w-10" />
-      </Button>
-    </div>
+      {/* 문제 추가/수정 모달 */}
+      <ProblemModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        mode={modalMode}
+        initialData={selectedQuestion}
+      />
+    </>
   )
 }

--- a/src/components/detail-exam/problem/EmptyProblems.tsx
+++ b/src/components/detail-exam/problem/EmptyProblems.tsx
@@ -1,21 +1,32 @@
 import EmptyFace from '@/assets/icons/EmptyFace.svg?react'
 import ProblemHeader from './ProblemHeader'
+import ProblemModal from '@/components/detail-exam/AddProblemModal/ProblemModal'
+import { useState } from 'react'
 
 export default function EmptyProblems() {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
   return (
-    <div className="mx-auto flex h-[600px] w-[1060px] flex-col rounded-xl border border-[#D9D9D9] bg-white p-7 shadow-sm">
-      <ProblemHeader />
-      <div className="flex flex-1 flex-col items-center justify-center gap-6">
-        <EmptyFace />
-        <div className="flex flex-col gap-2 text-center">
-          <h3 className="text-grey-800 text-lg font-semibold">
-            등록된 문제가 없습니다.
-          </h3>
-          <p className="text-grey-600">
-            수강생들이 학습할 수 있도록 문제를 등록해주세요!
-          </p>
+    <>
+      <div className="mx-auto flex h-[600px] w-[1060px] flex-col rounded-xl border border-[#D9D9D9] bg-white p-7 shadow-sm">
+        <ProblemHeader onAdd={() => setIsModalOpen(true)} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-6">
+          <EmptyFace />
+          <div className="flex flex-col gap-2 text-center">
+            <h3 className="text-grey-800 text-lg font-semibold">
+              등록된 문제가 없습니다.
+            </h3>
+            <p className="text-grey-600">
+              수강생들이 학습할 수 있도록 문제를 등록해주세요!
+            </p>
+          </div>
         </div>
       </div>
-    </div>
+      <ProblemModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        mode="create"
+      />
+    </>
   )
 }

--- a/src/components/detail-exam/problem/ProblemHeader.tsx
+++ b/src/components/detail-exam/problem/ProblemHeader.tsx
@@ -14,8 +14,8 @@ const TYPE_LABELS: Record<QuestionType, string> = {
 interface ProblemHeaderProps {
   type?: QuestionType
   onAdd: () => void
-  onEdit: () => void
-  // onDelete: () => void
+  onEdit?: () => void
+  // onDelete?: () => void
 }
 
 export default function ProblemHeader({

--- a/src/components/detail-exam/problem/ProblemHeader.tsx
+++ b/src/components/detail-exam/problem/ProblemHeader.tsx
@@ -5,17 +5,29 @@ import type { QuestionType } from '@/types/question'
 
 const TYPE_LABELS: Record<QuestionType, string> = {
   multiple_choice: '다지선다형',
-  true_false: '참/거짓형 (O/X)',
+  ox: '참/거짓형 (O/X)',
   ordering: '순서정렬',
   short_answer: '주관식(단답형)',
-  fill_in_the_blank: '빈칸식',
+  fill_blank: '빈칸식',
 }
 
-export default function ProblemHeader({ type }: { type?: QuestionType }) {
+interface ProblemHeaderProps {
+  type?: QuestionType
+  onAdd: () => void
+  onEdit: () => void
+  // onDelete: () => void
+}
+
+export default function ProblemHeader({
+  type,
+  onAdd,
+  onEdit,
+  // onDelete,
+}: ProblemHeaderProps) {
   if (!type) {
     return (
       <section className="flex items-center justify-end">
-        <button type="button" className="cursor-pointer">
+        <button type="button" className="cursor-pointer" onClick={onAdd}>
           <AddProblem />
         </button>
       </section>
@@ -28,10 +40,10 @@ export default function ProblemHeader({ type }: { type?: QuestionType }) {
     <section className="flex items-center justify-between">
       <h2 className="text-grey-600 text-sm font-normal">{label}</h2>
       <div className="flex items-center gap-2">
-        <button type="button" className="cursor-pointer">
+        <button type="button" className="cursor-pointer" onClick={onAdd}>
           <AddProblem />
         </button>
-        <button type="button" className="cursor-pointer">
+        <button type="button" className="cursor-pointer" onClick={onEdit}>
           <PutProblem />
         </button>
         <button type="button" className="cursor-pointer">

--- a/src/components/detail-exam/problem/ProblemOption.tsx
+++ b/src/components/detail-exam/problem/ProblemOption.tsx
@@ -5,8 +5,8 @@ import { cn } from '@/lib/cn'
 
 interface ProblemOptionProps {
   type: QuestionType
-  options?: string[]
-  answer?: string | string[]
+  options: string[] | null
+  answer: any
 }
 
 export default function ProblemOption({
@@ -21,9 +21,7 @@ export default function ProblemOption({
           <div className="flex flex-col gap-11">
             {(options || []).map((option, i) => {
               const alphabet = String.fromCharCode(65 + i)
-              const isCorrect = Array.isArray(answer)
-                ? answer.includes(option)
-                : answer === option
+              const isCorrect = answer.includes(option)
 
               return (
                 <div
@@ -48,14 +46,12 @@ export default function ProblemOption({
             })}
           </div>
         )
-      case 'true_false':
+      case 'ox':
         return (
           <div className="flex flex-col gap-11">
             {['O', 'X'].map((option, i) => {
               const alphabet = String.fromCharCode(65 + i)
-              const isCorrect = Array.isArray(answer)
-                ? answer.includes(option)
-                : answer === option
+              const isCorrect = answer.includes(option)
 
               return (
                 <div
@@ -99,7 +95,7 @@ export default function ProblemOption({
             value="타입단언"
           />
         )
-      case 'fill_in_the_blank':
+      case 'fill_blank':
         return (
           <div className="flex flex-col gap-6">
             <div className="border-grey-300 flex w-2/3 flex-col gap-4 rounded-[8px] border p-6">

--- a/src/store/ProblemForm/useProblemFormStore.ts
+++ b/src/store/ProblemForm/useProblemFormStore.ts
@@ -2,12 +2,16 @@ import { create } from 'zustand'
 import type {
   QuestionType,
   Question,
-  QuestionRequestBody,
+  // QuestionRequestBody,
 } from '@/types/question'
 
+//  Constants
+const DEFAULT_PROBLEM_POINT = 5
+const DEFAULT_BLANK_COUNT = 0
+
+//
 interface ProblemFormState {
   // 모드 상태
-
   mode: 'create' | 'edit'
   // 폼 데이터 상태
   type: QuestionType
@@ -33,10 +37,7 @@ interface ProblemFormState {
 
   // 상태 초기화 함수
   reset: () => void
-  initializeForEdit: (question: Question) => void
-
-  // 백엔드 전송용 바디 생성 함수
-  toRequestBody: () => QuestionRequestBody
+  initializeForEdit: (data: Question) => void
 }
 
 const initialState = {
@@ -45,18 +46,25 @@ const initialState = {
   question: '',
   prompt: '',
   options: ['', ''],
-  blankCount: 0,
+  blankCount: DEFAULT_BLANK_COUNT,
   correctAnswers: '',
-  point: 5,
+  point: DEFAULT_PROBLEM_POINT,
   explanation: '',
 }
 
-export const useProblemFormStore = create<ProblemFormState>((set, get) => ({
+//  Store
+export const useProblemFormStore = create<ProblemFormState>((set) => ({
   ...initialState,
 
   // 문제 입력에서 사용되는 Setter 함수들
   setMode: (mode) => set({ mode }),
-  setType: (type) => set({ type }),
+  setType: (type) =>
+    set({
+      type,
+      options: ['', ''],
+      correctAnswers: '',
+      blankCount: DEFAULT_BLANK_COUNT,
+    }),
   setQuestion: (question) => set({ question }),
   setPrompt: (prompt) => set({ prompt }),
   setOptions: (options) => set({ options }),
@@ -70,130 +78,147 @@ export const useProblemFormStore = create<ProblemFormState>((set, get) => ({
 
   // edit 모드 - 기존 문제 데이터를 폼 초기값에 적용시키기
   initializeForEdit: (data: Question) => {
-    // 1. 공통 데이터 세팅
+    const {
+      type,
+      question,
+      prompt,
+      blank_count,
+      point,
+      explanation,
+      options,
+      correct_answer,
+    } = data
+
     set({
       mode: 'edit',
-      type: data.type,
-      question: data.question || '',
-      prompt: data.prompt || '',
-      blankCount: data.blank_count || 0,
-      point: data.point || 5,
-      explanation: data.explanation || '',
+      type: type,
+      question: question ?? '',
+      prompt: prompt ?? '',
+      blankCount: blank_count ?? DEFAULT_BLANK_COUNT,
+      point: point || DEFAULT_PROBLEM_POINT,
+      explanation: explanation ?? '',
     })
 
-    // 2. 타입별 데이터 파싱 및 세팅 -> 경우 계산하고 정답의 타입이 any이기 때문에 타입 가드 사용
-    if (data.type === 'multiple_choice') {
-      // 다지선다형
-      // 객관식: "0,2" -> [0, 2]
-      const answerArray =
-        typeof data.correct_answer === 'string'
-          ? data.correct_answer.split(',').map(Number)
-          : Array.isArray(data.correct_answer)
-            ? data.correct_answer.map(Number)
-            : [0]
-
-      set({
-        options: data.options || ['', ''],
-        correctAnswers: answerArray,
-      })
-    } else if (data.type === 'ox') {
-      // ox 형
-      // OX: "O" -> [0], "X" -> [1] 로 판단
-      const isO =
-        data.correct_answer === 'O' ||
-        (Array.isArray(data.correct_answer) && data.correct_answer[0] === 'O')
-      set({
-        correctAnswers: isO ? 'O' : 'X',
-      })
-    } else if (data.type === 'ordering') {
-      // 순서 정렬
-      // 순서정렬: "2,0,1" -> [2, 0, 1]
-      const orderArray =
-        typeof data.correct_answer === 'string'
-          ? data.correct_answer.split(',').map(Number)
-          : Array.isArray(data.correct_answer)
-            ? data.correct_answer.map(Number)
-            : []
-
-      set({
-        options: data.options || ['', ''],
-        correctAnswers: orderArray,
-      })
-    } else if (data.type === 'short_answer') {
-      // 주관식 단답형
-      // 단답형: 그대로 사용
-      set({
-        correctAnswers: Array.isArray(data.correct_answer)
-          ? data.correct_answer[0]
-          : String(data.correct_answer),
-      })
-    } else if (data.type === 'fill_blank') {
-      // 빈칸
-      // 빈칸: 배열 그대로 사용
-      const answerArray = Array.isArray(data.correct_answer)
-        ? data.correct_answer
-        : [String(data.correct_answer)]
-
-      set({
-        correctAnswers: answerArray,
-      })
-    }
-  },
-
-  // [변환] 백엔드 전송용 바디 생성
-  toRequestBody: () => {
-    const state = get()
-    let submitCorrectAnswer: string | string[] = '' // 정답 초기화 변수
-    let submitOptions: string[] | null = state.options // 보기 초기화 변수
-    let submitBlankCount = 0 // 빈칸 초기화 변수
-
-    switch (state.type) {
+    switch (type) {
       case 'multiple_choice':
-        // [1, 3] -> "1,3" (오름차순 정렬) 나중에 받을 때 편하게
-        submitCorrectAnswer = [...state.correctAnswers]
-          .sort((a, b) => a - b)
-          .join(',')
+        // 다지선다형
+        // 객관식: "0,2" -> [0, 2]
+        set({
+          options: options ?? ['', ''],
+          correctAnswers:
+            typeof correct_answer === 'string'
+              ? correct_answer.split(',')
+              : Array.isArray(correct_answer)
+                ? correct_answer
+                : [0],
+        })
         break
 
       case 'ox':
-        // [0] -> "O", [1] -> "X" 변환해서 전달
-        submitCorrectAnswer = state.correctAnswers[0] === 0 ? 'O' : 'X'
-        submitOptions = null
+        // ox 형
+        // OX: "O" -> [0], "X" -> [1] 로 판단
+        set({
+          correctAnswers:
+            correct_answer === 'O' ||
+            (Array.isArray(correct_answer) && correct_answer[0] === 'O')
+              ? 'O'
+              : 'X',
+        })
         break
 
       case 'ordering':
-        submitCorrectAnswer = state.correctAnswers.join(',')
+        // 순서 정렬
+        // 순서정렬: "2,0,1" -> [2, 0, 1]
+        set({
+          options: options ?? ['', ''],
+          correctAnswers:
+            typeof correct_answer === 'string'
+              ? correct_answer.split(',').map(Number)
+              : Array.isArray(correct_answer)
+                ? correct_answer.map(Number)
+                : [],
+        })
         break
 
       case 'short_answer':
-        // "정답" -> "정답"
-        submitCorrectAnswer = state.correctAnswers
-        submitOptions = null
+        // 주관식 단답형
+        // 단답형: 그대로 사용
+        set({
+          correctAnswers: (correct_answer as string) ?? '',
+        })
         break
 
       case 'fill_blank':
-        // ["답1", "답2"] -> ["답1", "답2"]
-        submitCorrectAnswer = state.correctAnswers
-        submitOptions = null
-        submitBlankCount = state.correctAnswers.length
+        // 빈칸
+        // 빈칸: 배열 그대로 사용
+        set({
+          correctAnswers: correct_answer,
+          blankCount: Array.isArray(correct_answer)
+            ? correct_answer.length
+            : [String(correct_answer)].length,
+        })
         break
     }
-
-    // 다지선다랑 순서 정렬 빼고는 보기가 필요없음
-    if (state.type !== 'multiple_choice' && state.type !== 'ordering') {
-      submitOptions = null
-    }
-
-    // 최종 requestBody 반환
-    return {
-      type: state.type,
-      question: state.question,
-      prompt: state.prompt,
-      options: submitOptions,
-      blank_count: submitBlankCount,
-      correct_answer: submitCorrectAnswer,
-      point: state.point,
-      explanation: state.explanation,
-    }
   },
+
+  // const NEEDS_OPTIONS: Record<QuestionType, boolean> = {
+  //   multiple_choice: true,
+  //   ordering: true,
+  //   ox: false,
+  //   short_answer: false,
+  //   fill_blank: false,
+  // }
+
+  // const shouldSendOptions = (type: QuestionType) => NEEDS_OPTIONS[type]
+
+  // // [변환] 백엔드 전송용 바디 생성
+  // toRequestBody: () => {
+  //   const state = get()
+  //   let submitCorrectAnswer: string | string[] = '' // 정답 초기화 변수
+  //   let submitBlankCount = 0 // 빈칸 초기화 변수
+
+  //   switch (state.type) {
+  //     case 'multiple_choice':
+  //       // [1, 3] -> "1,3" (오름차순 정렬) 나중에 받을 때 편하게
+  //       submitCorrectAnswer = [...state.correctAnswers]
+  //         .sort((a, b) => a - b)
+  //         .join(',')
+  //       break
+
+  //     case 'ox':
+  //       // [0] -> "O", [1] -> "X" 변환해서 전달
+  //       submitCorrectAnswer = state.correctAnswers[0] === 0 ? 'O' : 'X'
+  //       break
+
+  //     case 'ordering':
+  //       submitCorrectAnswer = state.correctAnswers.join(',')
+  //       break
+
+  //     case 'short_answer':
+  //       // "정답" -> "정답"
+  //       submitCorrectAnswer = state.correctAnswers
+  //       break
+
+  //     case 'fill_blank':
+  //       // ["답1", "답2"] -> ["답1", "답2"]
+  //       submitCorrectAnswer = state.correctAnswers
+  //       submitBlankCount = state.correctAnswers.length
+  //       break
+  //   }
+
+  //   // 다지선다랑 순서 정렬 빼고는 보기가 필요없음
+  //   const submitOptions = shouldSendOptions(state.type) ? state.options : null;
+
+  //   // 최종 requestBody 반환
+  //   return {
+  //     type: state.type,
+  //     question: state.question,
+  //     prompt: state.prompt,
+  //     options: submitOptions,
+  //     blank_count: submitBlankCount,
+  //     correct_answer: submitCorrectAnswer,
+  //     point: state.point,
+  //     explanation: state.explanation,
+  //   }
+  // },
 }))


### PR DESCRIPTION
## ✨ PR 개요
쪽지시험에서 출제하는 문제를 원하는대로 수정 할 수 있게 도와주는 입력 폼 UI를 제작하여 문제 페이지 내 추가 수정 클릭 하였을 시
문제 수정 창이 기존 문제의 정보를 받아와 모달로 띄워지게 구성

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #49 

## 🧩 작업 내용 (주요 변경사항)
- 문제 추가, 수정 모달을 문제 페이지로 로드
- 문제 수정시 초기 값을 불러오는 과정에서 타입 에러로 조회 정보를 제대로 가져오지 못하는 상황이 있어 store 코드에서 초기화 로직 개선 및 책임 분리 작업을 추가로 진행 feat.채코

## 📸 스크린샷 (선택)

1. 시험 정보 O
https://github.com/user-attachments/assets/e655a924-fc1b-47af-9b68-072a9d81aa03

2. 시험 정보 X
https://github.com/user-attachments/assets/c91ee9cf-9d4f-4c2c-8787-c1a52c87a38c



## 🧠 기타 참고사항
아직 modal의 상태에 대한 전역적 관리 단계 까지 진행하지 않아 문제 페이지 컴포넌트 하단부에 ProblemModal을 위치시켜 open상태를 통해 제어 하였습니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
