### PR TITLE
feat: 쪽지시험 배포 페이지 구현 조회 UI(#46)

### DIFF
--- a/src/components/common/DeploymentToggle.tsx
+++ b/src/components/common/DeploymentToggle.tsx
@@ -1,0 +1,26 @@
+type Props = {
+  checked: boolean
+  onChange: (value: boolean) => void
+}
+
+export default function DeploymentToggle({ checked, onChange }: Props) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={[
+        'relative inline-flex h-5 w-9 items-center rounded-full transition-colors',
+        checked ? 'bg-green-500' : 'bg-grey-300',
+      ].join(' ')}
+    >
+      <span
+        className={[
+          'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+          checked ? 'translate-x-4' : 'translate-x-1',
+        ].join(' ')}
+      />
+    </button>
+  )
+}

--- a/src/mocks/table-data/ExamDeploymentHistory.ts
+++ b/src/mocks/table-data/ExamDeploymentHistory.ts
@@ -1,0 +1,22 @@
+export type ExamDeploymentRow = {
+  id: number
+  title: string
+  subject: string
+  course: string
+  count: number
+  avg: number
+  createdAt: string
+  active: boolean
+}
+
+export const examDeploymentHistoryMock: ExamDeploymentRow[] =
+  Array.from({ length: 10 }, (_, i) => ({
+    id: i + 1,
+    title: `쪽지시험 ${i + 1}`,
+    subject: 'React',
+    course: '웹 개발 초격차 프론트엔드 부트캠프 8기',
+    count: 20,
+    avg: 80,
+    createdAt: '2025.02.01 11:22:28',
+    active: i % 2 === 0,
+  }))

--- a/src/pages/ExamDeploymentHistoryPage.tsx
+++ b/src/pages/ExamDeploymentHistoryPage.tsx
@@ -1,0 +1,89 @@
+
+import { useState } from 'react'
+import AdminContainer from '@/components/layout/AdminContainer'
+import DeploymentToggle from '@/components/common/DeploymentToggle'
+import { examDeploymentHistoryMock } from '@/mocks/table-data/ExamDeploymentHistory'
+import type { ExamDeploymentRow } from '@/mocks/table-data/ExamDeploymentHistory'
+
+export default function ExamDeploymentHistoryPage() {
+  const [rows, setRows] = useState<ExamDeploymentRow[]>(examDeploymentHistoryMock)
+
+  const handleToggle = (id: number, value: boolean) => {
+    setRows(prev =>
+      prev.map(row => (row.id === id ? { ...row, active: value } : row))
+    )
+  }
+
+  return (
+    <AdminContainer title="쪽지시험 배포 내역 조회">
+      <div className="bg-white border border-[#DDDDDD] rounded-sm">
+        <div className="px-6 pt-4 pb-5">
+
+          {/* 검색 영역 */}
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-3">
+              <input
+                className="h-10 w-[260px] border border-[#E5E5EC] text-sm px-4 rounded-md"
+                placeholder="검색어를 입력하세요."
+              />
+              <button className="h-10 w-[72px] bg-[#E5E5EC] text-sm text-[#6B6B80] rounded-md">
+                조회
+              </button>
+            </div>
+
+            <button className="flex h-10 items-center gap-2 bg-[#F3F0FF] text-sm text-[#6C5DD3] px-4 rounded-md">
+              🔍 과목별 필터링
+            </button>
+          </div>
+
+          {/* 테이블 */}
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[1200px] text-sm">
+              <thead>
+                <tr className="bg-[#F7F7F7]">
+                  {[
+                    'ID','제목','과목명','과정 / 기수',
+                    '응시 수','평균','배포 생성 일시','배포 활성 상태'
+                  ].map(h => (
+                    <th
+                      key={h}
+                      className="h-[50px] px-2 border-b border-[#DDDDDD] text-[#6B6B80] font-normal text-center"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+
+              <tbody>
+                {rows.map(row => (
+                  <tr key={row.id} className="h-[54px] border-b border-[#EEEEEE]">
+                    <td className="px-2 text-center">{row.id}</td>
+                    <td className="px-2 text-left underline text-[#6B6B80]">{row.title}</td>
+                    <td className="px-2 text-center">{row.subject}</td>
+                    <td className="px-2 text-center">{row.course}</td>
+                    <td className="px-2 text-center">{row.count}</td>
+                    <td className="px-2 text-center">{row.avg}</td>
+                    <td className="px-2 text-center">{row.createdAt}</td>
+                    <td className="px-2 text-center">
+                      <DeploymentToggle
+                        checked={row.active}
+                        onChange={v => handleToggle(row.id, v)}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* 페이지네이션 */}
+          <div className="flex justify-center mt-3 text-sm">
+            « 1 2 3 4 5 »
+          </div>
+
+        </div>
+      </div>
+    </AdminContainer>
+  )
+}


### PR DESCRIPTION
## ✨ PR 개요
쪽지시험 배포 내역 조회 페이지 UI 구현

## 📌 관련 이슈
Closes # 46

## 🧩 작업 내용 (주요 변경사항)
- 배포 페이지, 토글 구현

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<img width="1470" height="956" alt="스크린샷 2026-01-30 오후 5 19 13" src="https://github.com/user-attachments/assets/906d16a1-9c62-4571-9a72-2a02a0e810c3" />


## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
