### PR TITLE
feat: 유저관리 페이지 api 연동 (#163)

### DIFF
--- a/src/components/common/MemberStatusBadge.tsx
+++ b/src/components/common/MemberStatusBadge.tsx
@@ -2,7 +2,8 @@ import type { BadgeProps } from '@/components/common/Badge'
 import { Badge } from '@/components/common'
 
 export type MemberStatus =
-  | 'Activated'
+  | 'active'
+  | 'Activated' // mock 등 레거시용
   | 'Disabled'
   | 'Withdraw'
   | 'Submitted'
@@ -14,7 +15,8 @@ export type MemberStatus =
   | 'Staff'
   | 'Admin'
 
-const STATUS_TO_VARIANT = {
+const STATUS_TO_VARIANT: Record<MemberStatus, BadgeProps['variant']> = {
+  active: 'primary',
   Activated: 'primary',
   Disabled: 'danger',
   Withdraw: 'success',
@@ -43,7 +45,7 @@ export function MemberStatusBadge({
       size="status"
       className={className}
     >
-      {status}
+      {status === 'active' || status === 'Activated' ? 'Active' : status}
     </Badge>
   )
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,4 +1,7 @@
 export const API_PATHS = {
+  ACCOUNTS: {
+    LIST: '/api/v1/admin/accounts/',
+  },
   AUTH: {
     LOGIN: '/api/v1/accounts/login/',
     REFRESH_TOKEN: '/api/v1/accounts/me/refresh/',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useAdminAccounts'
 export * from './useAxios'
 export * from './useFilter'
 export * from './useExamUpload'

--- a/src/hooks/useAdminAccounts.ts
+++ b/src/hooks/useAdminAccounts.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { API_PATHS } from '@/constants/api'
+import type {
+  AdminAccountListResponse,
+  AdminAccountListItem,
+  Member,
+  MemberRole,
+} from '@/types/member'
+import type { MemberStatus } from '@/components/common'
+import { useAxios } from './useAxios'
+
+const DEFAULT_PAGE_SIZE = 20
+
+function mapAccountToMember(item: AdminAccountListItem): Member {
+  const role = (item.role ?? 'General') as MemberRole
+  const status = (item.status ?? 'active') as MemberStatus
+  return {
+    id: item.id,
+    nickname: item.nickname ?? '',
+    name: item.name ?? '-',
+    email: item.email,
+    phone: item.phone_number,
+    birthDate: item.birthday ?? '-',
+    role,
+    status,
+    joinedAt: item.created_at ?? '-',
+  }
+}
+
+export function useAdminAccounts(options?: {
+  page?: number
+  page_size?: number
+}) {
+  const { sendRequest, isLoading } = useAxios()
+  const [members, setMembers] = useState<Member[]>([])
+  const [totalCount, setTotalCount] = useState(0)
+
+  const page = options?.page ?? 1
+  const pageSize = options?.page_size ?? DEFAULT_PAGE_SIZE
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const data = await sendRequest<AdminAccountListResponse>({
+          method: 'GET',
+          url: API_PATHS.ACCOUNTS.LIST,
+          params: { page, page_size: pageSize },
+          errorTitle: '유저 목록 조회에 실패했습니다.',
+        })
+
+        if (data?.results) {
+          setMembers(data.results.map(mapAccountToMember))
+          setTotalCount(data.count ?? data.results.length)
+        } else {
+          setMembers([])
+          setTotalCount(0)
+        }
+      } catch {
+        setMembers([])
+        setTotalCount(0)
+      }
+    }
+
+    void fetchAccounts()
+  }, [sendRequest, page, pageSize])
+
+  return {
+    members,
+    totalCount,
+    isLoading,
+  }
+}

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -19,7 +19,7 @@ const ROLE_OPTIONS: DropdownOption[] = [
 ]
 
 const STATUS_OPTIONS: DropdownOption[] = [
-  { label: 'Activated', value: 'Activated' },
+  { label: 'Active', value: 'active' },
   { label: 'Disabled', value: 'Disabled' },
   { label: 'Withdraw', value: 'Withdraw' },
 ]
@@ -29,6 +29,7 @@ type ManagementPageProps = {
   listVariant: 'member' | 'student'
   listData: Member[]
   enableDetail?: boolean
+  externalLoading?: boolean
 }
 
 export default function ManagementPage({
@@ -36,6 +37,7 @@ export default function ManagementPage({
   listVariant,
   listData,
   enableDetail = true,
+  externalLoading,
 }: ManagementPageProps) {
   const showRoleFilter = listVariant === 'member'
   const [roleInput, setRoleInput] = useState<MemberRole | undefined>()
@@ -49,15 +51,22 @@ export default function ManagementPage({
   const [selectedMember, setSelectedMember] = useState<Member | null>(null)
   const [memberList, setMemberList] = useState(listData)
   const showToast = useToastStore((state) => state.showToast)
-  const [isLoading, setIsLoading] = useState(true)
+  const [internalLoading, setInternalLoading] = useState(
+    externalLoading === undefined
+  )
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false)
-    }, 3000)
+    setMemberList(listData)
+  }, [listData])
 
+  useEffect(() => {
+    if (externalLoading !== undefined) return
+    const timer = setTimeout(() => setInternalLoading(false), 3000)
     return () => clearTimeout(timer)
-  }, [])
+  }, [externalLoading])
+
+  const isLoading =
+    externalLoading !== undefined ? externalLoading : internalLoading
 
   const handleSearch = () => {
     setRole(roleInput ?? 'ALL')

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -61,7 +61,7 @@ export default function ManagementPage({
 
   useEffect(() => {
     if (externalLoading !== undefined) return
-    const timer = setTimeout(() => setInternalLoading(false), 3000)
+    const timer = setTimeout(() => setInternalLoading(false), 500)
     return () => clearTimeout(timer)
   }, [externalLoading])
 

--- a/src/pages/member-management/MemberManagementPage.tsx
+++ b/src/pages/member-management/MemberManagementPage.tsx
@@ -1,12 +1,18 @@
 import ManagementPage from './ManagementPage'
-import { MOCK_MEMBER_LIST_RESPONSE } from '@/mocks/data/table-data/MemberList'
+import { useAdminAccounts } from '@/hooks'
 
 export function MemberManagementPage() {
+  const { members, isLoading } = useAdminAccounts({
+    page: 1,
+    page_size: 20,
+  })
+
   return (
     <ManagementPage
       title="회원관리"
       listVariant="member"
-      listData={MOCK_MEMBER_LIST_RESPONSE.members}
+      listData={members}
+      externalLoading={isLoading}
     />
   )
 }

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -147,3 +147,23 @@ export interface PaginatedWithdrawalResponse<T> {
   previous: string | null
   results: T[]
 }
+
+// GET /api/v1/admin/accounts/ 응답 항목 (200 예제값·스키마 기준)
+export type AdminAccountListItem = {
+  id: number
+  email: string
+  nickname?: string
+  name?: string
+  phone_number?: string
+  birthday?: string
+  status?: string
+  role?: string
+  created_at?: string
+}
+
+export type AdminAccountListResponse = {
+  count: number
+  next: string | null
+  previous: string | null
+  results: AdminAccountListItem[]
+}


### PR DESCRIPTION
## ✨ PR 개요
회원관리 페이지에 관리자 계정 목록 API를 연동하고, API 회원 상태 값 active에 맞춰 프론트 타입·필터·배지 표시를 정리했습니다.

## 📌 관련 이슈
Closes #163 

## 🧩 작업 내용 (주요 변경사항)
- API 연동
- ManagementPage 공통화
- 회원 상태(active) 정리
- Skeleton 지연 값 3000 -> 500 수정

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<img width="1512" height="830" alt="스크린샷 2026-02-11 11 23 39" src="https://github.com/user-attachments/assets/f42ea595-e563-4b90-8b8f-df1025a1f72c" />

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료