### PR TITLE
feat: ADMIN 시험에서 추가 수정 삭제 시 성공 실패 Toast 처리 (#164)

### DIFF
--- a/src/components/common/ErrorCatcher.tsx
+++ b/src/components/common/ErrorCatcher.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useErrorStore, useAlertStore } from '@/store'
+import { useErrorStore, useAlertStore, useToastStore } from '@/store'
 // 전역 에러 상태를 감시하여 UI를 트리거
 
 export function ErrorCatcher() {
@@ -20,7 +20,10 @@ export function ErrorCatcher() {
         description: message || '',
       })
     } else if (mode === 'toast') {
-      // toast 기능 구현 시 연동
+      useToastStore.getState().showToast({
+        message: message || '해당 과정을 진행하는 중 오류가 발생하였습니다.',
+        variant: 'error',
+      })
     }
 
     // 출력 후 스토어 비우기

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -13,7 +13,6 @@ export const API_PATHS = {
     LIST: '/api/v1/admin/exams',
     DETAIL: (examId: number | string) => `/api/v1/admin/exams/${examId}`,
     PRESIGNED_URL: '/api/v1/admin/exams/presigned-url/thumbnail',
-    CREATE: '/api/v1/admin/exams',
     UPDATE: (examId: number | string) => `/api/v1/admin/exams/${examId}`,
     DELETE: (examId: number | string) => `/api/v1/admin/exams/${examId}`,
   },

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -11,10 +11,9 @@ export const API_PATHS = {
   },
   EXAM: {
     LIST: '/api/v1/admin/exams',
+    CREATE: '/api/v1/admin/exams',
     DETAIL: (examId: number | string) => `/api/v1/admin/exams/${examId}`,
     PRESIGNED_URL: '/api/v1/admin/exams/presigned-url/thumbnail',
-    UPDATE: (examId: number | string) => `/api/v1/admin/exams/${examId}`,
-    DELETE: (examId: number | string) => `/api/v1/admin/exams/${examId}`,
   },
   QUESTION: {
     CREATE: (examId: number | string) =>

--- a/src/hooks/useExamUpload.ts
+++ b/src/hooks/useExamUpload.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { useAxios } from '@/hooks'
 import { API_PATHS } from '@/constants/api'
 import axios from 'axios'
+import { useToastStore } from '@/store'
 
 interface PresignedUrlResponse {
   presigned_url: string
@@ -70,14 +71,28 @@ export function useExamUpload({
         payload.thumbnail_img_url = targetImgUrl
       }
 
-      const response = await sendRequest({
-        method: mode === 'create' ? 'POST' : 'PUT',
-        url:
-          mode === 'create' ? API_PATHS.EXAM.LIST : API_PATHS.EXAM.DETAIL(id!),
-        data: payload,
-      })
+      const response = await sendRequest(
+        {
+          method: mode === 'create' ? 'POST' : 'PUT',
+          url:
+            mode === 'create'
+              ? API_PATHS.EXAM.LIST
+              : API_PATHS.EXAM.DETAIL(id!),
+          data: payload,
+        },
+        {
+          onError: (error) => {
+            error.mode = 'toast'
+            error.message = `${mode === 'create' ? '쪽지시험 생성' : '쪽지시험 수정'}에 실패했습니다.`
+          },
+        }
+      )
 
       if (response) {
+        useToastStore.getState().showToast({
+          message: `성공적으로 ${mode === 'create' ? '쪽지시험 생성' : '쪽지시험 수정'}에 성공했습니다.`,
+          variant: 'success',
+        })
         onSuccess?.()
         onClose()
       }

--- a/src/pages/exam-page/exam-list/DetailExamPage.tsx
+++ b/src/pages/exam-page/exam-list/DetailExamPage.tsx
@@ -7,6 +7,7 @@ import { ExamHistoryLayout } from '@/components/layout'
 import { useAxios } from '@/hooks'
 import { API_PATHS } from '@/constants/api'
 import type { QuestionsList } from '@/types/question'
+import { useToastStore } from '@/store'
 
 export function DetailExamPage() {
   const { id } = useParams<{ id: string }>()
@@ -36,13 +37,24 @@ export function DetailExamPage() {
   const handleDelete = async () => {
     if (!id) return
 
-    const success = await sendRequest({
-      method: 'DELETE',
-      url: API_PATHS.EXAM.DETAIL(id),
-      errorTitle: '삭제 실패',
-    })
+    const success = await sendRequest(
+      {
+        method: 'DELETE',
+        url: API_PATHS.EXAM.DETAIL(id),
+      },
+      {
+        onError: (error) => {
+          error.mode = 'toast'
+          error.message = '쪽지시험 삭제에 실패했습니다.'
+        },
+      }
+    )
 
     if (success) {
+      useToastStore.getState().showToast({
+        message: '쪽지시험이 삭제되었습니다.',
+        variant: 'success',
+      })
       setIsDeleteModalOpen(false)
       navigate('/exam/list')
     }


### PR DESCRIPTION
## ✨ PR 개요
쪽지시험 파트에서 등록 , 수정 , 삭제 완료 처리를 전달할 수 있는 Toast를 연동

## 📌 관련 이슈
Closes #164 

## 🧩 작업 내용 (주요 변경사항)
-  API 요청시 onError에 err.mode를 toast로 받으면 에러 발생시 오류 toast를 띄울수 있게 ErrorCatcher에 로직을 추가
- 쪽지시험 수정 생성 요청 시 onError에 toast 정보를 주입해 error 객체에 요청 실패 시 오류 토스트를 원한다고 전달하고 성공하였으면 ToastStore로 보내 성공 알림
- 쪽지시험 삭제 요청 시에도 똑같이 작업
- 
## 📸 스크린샷 (선택)
1. 성공 시나리오

https://github.com/user-attachments/assets/697577c7-24f1-4ea5-acc2-fc00ee2cd91d



2. 실패 시나리오
1) 생성

https://github.com/user-attachments/assets/358348a0-42db-4743-b5ba-ec6a79bf8fd5


2) 수정 삭제


https://github.com/user-attachments/assets/0c6e9a9d-80e2-48b6-b692-c58dd7bdf707



## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
