### PR TITLE
feat: 유저관리 상세모달 api 연동 (#166)

### DIFF
--- a/src/components/common/MemberStatusBadge.tsx
+++ b/src/components/common/MemberStatusBadge.tsx
@@ -2,8 +2,7 @@ import type { BadgeProps } from '@/components/common/Badge'
 import { Badge } from '@/components/common'
 
 export type MemberStatus =
-  | 'active'
-  | 'Activated' // mock 등 레거시용
+  | 'Activated'
   | 'Disabled'
   | 'Withdraw'
   | 'Submitted'
@@ -16,7 +15,6 @@ export type MemberStatus =
   | 'Admin'
 
 const STATUS_TO_VARIANT: Record<MemberStatus, BadgeProps['variant']> = {
-  active: 'primary',
   Activated: 'primary',
   Disabled: 'danger',
   Withdraw: 'success',
@@ -45,7 +43,7 @@ export function MemberStatusBadge({
       size="status"
       className={className}
     >
-      {status === 'active' || status === 'Activated' ? 'Active' : status}
+      {status}
     </Badge>
   )
 }

--- a/src/components/member-management/MemberDetailModal.tsx
+++ b/src/components/member-management/MemberDetailModal.tsx
@@ -9,9 +9,10 @@ import ModifyPermissionModal, {
   type Option,
   type PermissionValue,
 } from './ModifyPermissionModal'
+import { useAdminAccountDetail } from '@/hooks'
 import { MOCK_MEMBER_DETAIL_MAP } from '@/mocks/data/member-detail'
 import type { Member, MemberDetail } from '@/types'
-import memberImg from '@/assets/MemberImg.jpeg'
+import { formatDate, formatDateTime } from '@/utils'
 import {
   TableWrap,
   TableRow,
@@ -21,7 +22,6 @@ import {
   RoleLabel,
 } from './MemberDetailTable'
 
-const DEFAULT_MEMBER_IMAGE_URL = memberImg
 const DETAIL_TABLE_COLUMNS = '141px 130px minmax(0,1fr) 100px minmax(0,1fr)'
 const META_TABLE_COLUMNS =
   '141px minmax(0,1fr) minmax(0,1fr) 100px minmax(0,1fr)'
@@ -69,19 +69,24 @@ export function MemberDetailModal({
     cohort: '',
   })
 
-  const detail = useMemo<MemberDetail | null>(() => {
-    if (!member) return null
+  const accountId = member?.id ?? null
+  const { detail: apiDetail, isLoading: isDetailLoading } =
+    useAdminAccountDetail(accountId)
 
+  const fallbackDetail = useMemo<MemberDetail | null>(() => {
+    if (!member) return null
     return (
       MOCK_MEMBER_DETAIL_MAP[member.id] ?? {
         ...member,
         gender: '미설정',
         phone: '-',
-        Courses: [],
+        ongoingCourses: [],
         cohorts: [],
       }
     )
   }, [member])
+
+  const detail = apiDetail ?? fallbackDetail
 
   useEffect(() => {
     if (!open) {
@@ -143,6 +148,11 @@ export function MemberDetailModal({
         <Modal.Body className="flex h-full flex-col px-8 pt-8 pb-6">
           <div className="mb-6">
             <h2 className="text-grey-800 text-lg font-bold">회원정보</h2>
+            {isDetailLoading && !apiDetail && (
+              <p className="text-grey-500 mt-1 text-xs">
+                상세 정보를 불러오는 중입니다...
+              </p>
+            )}
           </div>
 
           <div className="flex flex-grow flex-col space-y-6">
@@ -150,9 +160,7 @@ export function MemberDetailModal({
               <TableWrap rows={4} columns={DETAIL_TABLE_COLUMNS}>
                 <TableRow>
                   <ProfileImageCell
-                    imageUrl={
-                      detail.profileImageUrl ?? DEFAULT_MEMBER_IMAGE_URL
-                    }
+                    imageUrl={detail.profileImageUrl}
                     alt={`${detail.nickname} 프로필`}
                   />
                   <ThCell>ID</ThCell>
@@ -170,7 +178,9 @@ export function MemberDetailModal({
                   <ThCell>닉네임</ThCell>
                   <TdCell>{detail.nickname}</TdCell>
                   <ThCell>생년월일</ThCell>
-                  <TdCell>{detail.birthDate}</TdCell>
+                  <TdCell>
+                    {detail.birthDate ? formatDate(detail.birthDate) : '-'}
+                  </TdCell>
                 </TableRow>
 
                 <TableRow>
@@ -192,7 +202,9 @@ export function MemberDetailModal({
                 </TableRow>
                 <TableRow>
                   <ThCell>가입일</ThCell>
-                  <TdCell colSpan={4}>{detail.joinedAt}</TdCell>
+                  <TdCell colSpan={4}>
+                    {detail.joinedAt ? formatDateTime(detail.joinedAt) : '-'}
+                  </TdCell>
                 </TableRow>
                 <TableRow>
                   <ThCell>권한</ThCell>

--- a/src/components/member-management/MemberDetailTable.tsx
+++ b/src/components/member-management/MemberDetailTable.tsx
@@ -86,7 +86,7 @@ export function TdCell({
 const ROLE_LABEL_MAP: Record<MemberRole, string> = {
   Admin: 'Admin',
   'Staff (TA)': 'Staff (TA)',
-  Student: '수강생',
+  Student: 'Student',
   General: 'General',
   'Staff (LC)': 'Staff (LC)',
   'Staff (OM)': 'Staff (OM)',
@@ -102,7 +102,7 @@ export function ProfileImageCell({
   showEditIcon = false,
   onEditClick,
 }: {
-  imageUrl: string
+  imageUrl?: string
   alt: string
   showEditIcon?: boolean
   onEditClick?: () => void
@@ -110,11 +110,20 @@ export function ProfileImageCell({
   return (
     <TdCell rowSpan={4} className="overflow-hidden !p-0">
       <div className="bg-grey-100 relative h-[199px] w-[141px] overflow-hidden">
-        <img
-          src={imageUrl}
-          alt={alt}
-          className="block h-full w-full object-cover"
-        />
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={alt}
+            className="block h-full w-full object-cover"
+          />
+        ) : (
+          <div
+            className="text-grey-500 flex h-full w-full items-center justify-center text-sm"
+            aria-label={alt}
+          >
+            이미지 없음
+          </div>
+        )}
         {showEditIcon && (
           <button
             type="button"

--- a/src/components/table/MemberList.tsx
+++ b/src/components/table/MemberList.tsx
@@ -1,10 +1,8 @@
 import { useMemo, useState } from 'react'
-import { Pagination } from '@/components/common/Pagination'
-import { MemberStatusBadge } from '@/components/common'
+import { MemberStatusBadge, Pagination } from '@/components/common'
 import { DataTable, type Column } from './data-table/DataTable'
 import type { Member } from '@/types/member'
-
-const getRoleLabel = (role: Member['role']) => role
+import { RoleLabel } from '@/components/member-management/MemberDetailTable'
 
 type MemberListProps = {
   data: Member[]
@@ -78,7 +76,7 @@ const MEMBER_COLUMNS = (
     key: 'role',
     title: '권한',
     size: 'xl',
-    cell: (item) => getRoleLabel(item.role),
+    cell: (item) => <RoleLabel role={item.role} />,
   },
   {
     key: 'birthDate',
@@ -139,7 +137,7 @@ const STUDENT_COLUMNS = (): Column<Member>[] => [
     key: 'role',
     title: '권한',
     size: 'xl',
-    cell: (item) => getRoleLabel(item.role),
+    cell: (item) => <RoleLabel role={item.role} />,
   },
   {
     key: 'course',

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,6 +1,8 @@
 export const API_PATHS = {
   ACCOUNTS: {
     LIST: '/api/v1/admin/accounts/',
+    DETAIL: (accountId: number | string) =>
+      `/api/v1/admin/accounts/${accountId}/`,
   },
   AUTH: {
     LOGIN: '/api/v1/accounts/login/',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useAdminAccountDetail'
 export * from './useAdminAccounts'
 export * from './useAxios'
 export * from './useFilter'

--- a/src/hooks/useAdminAccountDetail.ts
+++ b/src/hooks/useAdminAccountDetail.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { API_PATHS } from '@/constants/api'
+import type { AdminAccountDetail, MemberDetail } from '@/types/member'
+import { useAxios } from './useAxios'
+import {
+  mapApiRoleToMemberRole,
+  mapApiStatusToMemberStatus,
+} from '@/utils/accountMapping'
+
+function mapGender(apiGender?: string): '남' | '여' | '미설정' {
+  if (apiGender === 'MALE') return '남'
+  if (apiGender === 'FEMALE') return '여'
+  return '미설정'
+}
+
+function getCourseName(entry: {
+  course?: string | { id?: number; name?: string; course_name?: string }
+  cohort?: number | { id?: number; number?: number }
+  course_name?: string
+}): string {
+  if (entry.course_name && typeof entry.course_name === 'string')
+    return entry.course_name
+  const c = entry.course
+  if (typeof c === 'string') return c
+  if (c && typeof c === 'object')
+    return (
+      (c as { name?: string; course_name?: string }).name ??
+      (c as { name?: string; course_name?: string }).course_name ??
+      ''
+    )
+  return ''
+}
+
+function getCohortDisplay(entry: {
+  course?: string | { id?: number; name?: string; course_name?: string }
+  cohort?: number | { id?: number; number?: number }
+}): string {
+  const co = entry.cohort
+  if (typeof co === 'number') return `${co}기`
+  if (co && typeof co === 'object' && 'number' in co)
+    return co.number != null ? `${co.number}기` : ''
+  return ''
+}
+
+function mapAccountDetailToMemberDetail(
+  item: AdminAccountDetail | null
+): MemberDetail | null {
+  if (!item) return null
+
+  const assigned = item.assigned_courses ?? []
+  const ongoingCourses = assigned
+    .map(getCourseName)
+    .filter((name): name is string => name.length > 0)
+  const cohorts = assigned
+    .map(getCohortDisplay)
+    .filter((s): s is string => s.length > 0)
+
+  return {
+    id: item.id,
+    nickname: item.nickname ?? '',
+    name: item.name ?? '-',
+    email: item.email,
+    phone: item.phone_number || undefined,
+    birthDate: item.birthday ?? '-',
+    role: mapApiRoleToMemberRole(item.role),
+    status: mapApiStatusToMemberStatus(item.status),
+    joinedAt: item.created_at ?? '-',
+    gender: mapGender(item.gender),
+    profileImageUrl: item.profile_img_url,
+    ongoingCourses,
+    cohorts,
+  }
+}
+
+export function useAdminAccountDetail(accountId: number | null) {
+  const { sendRequest, isLoading } = useAxios()
+  const [detail, setDetail] = useState<MemberDetail | null>(null)
+
+  useEffect(() => {
+    if (!accountId) {
+      setDetail(null)
+      return
+    }
+
+    const fetchDetail = async () => {
+      try {
+        const data = await sendRequest<AdminAccountDetail>({
+          method: 'GET',
+          url: API_PATHS.ACCOUNTS.DETAIL(accountId),
+          errorTitle: '회원 상세 조회에 실패했습니다.',
+        })
+        setDetail(mapAccountDetailToMemberDetail(data))
+      } catch {
+        setDetail(null)
+      }
+    }
+
+    void fetchDetail()
+  }, [sendRequest, accountId])
+
+  return {
+    detail,
+    isLoading,
+  }
+}

--- a/src/hooks/useAdminAccounts.ts
+++ b/src/hooks/useAdminAccounts.ts
@@ -4,16 +4,18 @@ import type {
   AdminAccountListResponse,
   AdminAccountListItem,
   Member,
-  MemberRole,
 } from '@/types/member'
-import type { MemberStatus } from '@/components/common'
 import { useAxios } from './useAxios'
+import {
+  mapApiRoleToMemberRole,
+  mapApiStatusToMemberStatus,
+} from '@/utils/accountMapping'
 
 const DEFAULT_PAGE_SIZE = 20
 
 function mapAccountToMember(item: AdminAccountListItem): Member {
-  const role = (item.role ?? 'General') as MemberRole
-  const status = (item.status ?? 'active') as MemberStatus
+  const role = mapApiRoleToMemberRole(item.role)
+  const status = mapApiStatusToMemberStatus(item.status)
   return {
     id: item.id,
     nickname: item.nickname ?? '',

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -19,7 +19,7 @@ const ROLE_OPTIONS: DropdownOption[] = [
 ]
 
 const STATUS_OPTIONS: DropdownOption[] = [
-  { label: 'Active', value: 'active' },
+  { label: 'Activated', value: 'Activated' },
   { label: 'Disabled', value: 'Disabled' },
   { label: 'Withdraw', value: 'Withdraw' },
 ]

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -167,3 +167,15 @@ export type AdminAccountListResponse = {
   previous: string | null
   results: AdminAccountListItem[]
 }
+
+/** GET /api/v1/admin/accounts/{id}/ 상세 응답 (retrieve) */
+export type AssignedCourseItem = {
+  course?: string | { id?: number; name?: string; course_name?: string }
+  cohort?: number | { id?: number; number?: number }
+  course_name?: string
+}
+export type AdminAccountDetail = AdminAccountListItem & {
+  profile_img_url?: string
+  gender?: string
+  assigned_courses?: AssignedCourseItem[]
+}

--- a/src/utils/accountMapping.ts
+++ b/src/utils/accountMapping.ts
@@ -1,0 +1,50 @@
+import type { MemberRole } from '@/types/member'
+import type { MemberStatus } from '@/components/common'
+
+/** API role 문자열 → 화면 표시용 MemberRole */
+const API_ROLE_MAP: Record<string, MemberRole> = {
+  USER: 'General',
+  user: 'General',
+  General: 'General',
+  general: 'General',
+  LC: 'Staff (LC)',
+  lc: 'Staff (LC)',
+  TA: 'Staff (TA)',
+  ta: 'Staff (TA)',
+  OM: 'Staff (OM)',
+  om: 'Staff (OM)',
+  ADMIN: 'Admin',
+  admin: 'Admin',
+  Admin: 'Admin',
+  STAFF: 'Staff (TA)',
+  staff: 'Staff (TA)',
+  STUDENT: 'Student',
+  student: 'Student',
+  Student: 'Student',
+  'Staff (TA)': 'Staff (TA)',
+  'Staff (LC)': 'Staff (LC)',
+  'Staff (OM)': 'Staff (OM)',
+}
+
+/** API status 문자열 → 화면 표시용 MemberStatus */
+const API_STATUS_MAP: Record<string, MemberStatus> = {
+  ACTIVATED: 'Activated',
+  activated: 'Activated',
+  Activated: 'Activated',
+  DISABLED: 'Disabled',
+  disabled: 'Disabled',
+  Disabled: 'Disabled',
+  WITHDRAW: 'Withdraw',
+  withdraw: 'Withdraw',
+  Withdraw: 'Withdraw',
+}
+
+export function mapApiRoleToMemberRole(apiRole?: string): MemberRole {
+  if (!apiRole) return 'General'
+  return API_ROLE_MAP[apiRole] ?? ('General' as MemberRole)
+}
+
+export function mapApiStatusToMemberStatus(apiStatus?: string): MemberStatus {
+  if (!apiStatus) return 'Activated'
+  return API_STATUS_MAP[apiStatus] ?? ('Activated' as MemberStatus)
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -36,3 +36,17 @@ export const formatDateTime = (dateString: string): string => {
 
   return `${year}.${month}.${day} ${hours}:${minutes}:${seconds}`
 }
+
+/**
+ * 날짜 문자열을 YYYY.MM.DD 형식으로 변환 (시간 제외)
+ */
+export const formatDate = (dateString: string): string => {
+  if (!dateString || dateString === '-') return dateString
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return dateString
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './accountMapping'
 export * from './dateUtils'
 export * from './logout'
 export * from './errorParser'


### PR DESCRIPTION
## ✨ PR 개요
회원 상세 모달에 GET /api/v1/admin/accounts/{submissions_id}/ API를 연동하고, API role/status 문자열 매핑 유틸을 추가해 회원관리 페이지와 상세 모달의 표시를 통일했습니다.

## 📌 관련 이슈
Closes #166 

## 🧩 작업 내용 (주요 변경사항)
- 회원 상세 조회 API 연동
- 날짜 포맷
- API role/status 매핑 유틸
- 회원상태 및 권한 표시 통일

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/6d080fb4-6fe1-479a-a5d3-4dd9845fd1e5

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료