### PR TITLE
feat: 쪽지시험 필터링 조회 기능 추가 (#168)

### DIFF
--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -63,10 +63,13 @@ export function useFilter(configs: FilterOptionConfig[]) {
   }, [configs, values])
 
   const canSubmit = useMemo(() => {
-    // 모든 필드 선택 되었는지 체크
+    // 선택된 값이 옵션 목록에 존재하는지 확인하는 방식으로변경
     return configs
       .filter((conf) => !conf.disabled)
-      .every((conf) => !!values[conf.key])
+      .every((conf) => {
+        const currentValue = values[conf.key]
+        return conf.options.some((opt) => opt.value === currentValue)
+      })
   }, [configs, values])
 
   return {

--- a/src/pages/exam-page/exam-list/ExamListPage.tsx
+++ b/src/pages/exam-page/exam-list/ExamListPage.tsx
@@ -151,8 +151,12 @@ export function ExamListPage() {
         }
       >
         {isLoading ? (
-          <div className="text-grey-500 flex h-60 items-center justify-center">
+          <div className="flex h-60 items-center justify-center">
             데이터를 불러오는 중입니다...
+          </div>
+        ) : paginatedData.length === 0 ? (
+          <div className="flex h-60 items-center justify-center">
+            존재하는 데이터가 없습니다.
           </div>
         ) : (
           <ExamList data={paginatedData} />

--- a/src/pages/exam-page/exam-list/ExamListPage.tsx
+++ b/src/pages/exam-page/exam-list/ExamListPage.tsx
@@ -12,41 +12,23 @@ import { API_PATHS } from '@/constants/api'
 import type { ExamListResponse } from '@/types/exam'
 import { useEffect, useState, useCallback } from 'react'
 import ExamModal from '@/components/detail-exam/exam-modal/ExamModal'
-import { COURSE_OPTIONS } from '@/constants/filtered-option'
+import { SUBJECT_OPTIONS } from '@/constants/filtered-option'
 
 export function ExamListPage() {
-  const [data, setData] = useState<ExamListResponse | null>(null)
-  const [isModalOpen, setIsModalOpen] = useState(false)
-  const [page, setPage] = useState(1)
-
   const { sendRequest, isLoading } = useAxios()
-
-  const fetchExams = useCallback(async () => {
-    const response = await sendRequest<ExamListResponse>({
-      method: 'GET',
-      url: API_PATHS.EXAM.LIST,
-      params: {
-        page,
-        size: 10,
-      },
-    })
-    if (response) {
-      setData(response)
-    }
-  }, [page, sendRequest])
-
-  useEffect(() => {
-    fetchExams()
-  }, [fetchExams])
+  const [data, setData] = useState<ExamListResponse | null>(null)
+  const [page, setPage] = useState(1)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   const totalPages = data ? Math.ceil(data.total_count / data.size) : 0
   const paginatedData = data?.exams || []
 
+  // 과정별 필터링
   const filterConfigs: FilterOptionConfig[] = [
     {
-      key: 'course',
-      placeholder: '과정을 선택해주세요',
-      options: COURSE_OPTIONS,
+      key: 'subject_id',
+      placeholder: '과목을 선택해주세요',
+      options: [{ label: '전체', value: '' }, ...SUBJECT_OPTIONS],
     },
   ]
 
@@ -54,12 +36,70 @@ export function ExamListPage() {
     isOpen: isFilterOpen,
     openFilter: handleOpenFilter,
     closeFilter: handleCloseFilter,
-    rows, // 필터 행
-    summary, // 필터 요약
-    canSubmit, // 필터 제출 가능 여부
+    values: filterValues,
+    rows,
+    summary,
+    canSubmit,
   } = useFilter(filterConfigs)
 
+  // 검색 및 필터 상태
+  const [searchText, setSearchText] = useState('')
+  const [queryParams, setQueryParams] = useState({
+    search_keyword: '',
+    subject_id: '',
+  })
+
+  // 데이터 조회
+  const fetchExams = useCallback(async () => {
+    const params: Record<string, any> = {
+      page,
+      size: 10,
+    }
+
+    if (queryParams.search_keyword) {
+      params.search_keyword = queryParams.search_keyword
+    }
+    if (queryParams.subject_id) {
+      params.subject_id = queryParams.subject_id
+    }
+
+    const response = await sendRequest<ExamListResponse>({
+      method: 'GET',
+      url: API_PATHS.EXAM.LIST,
+      params,
+    })
+    if (response) {
+      setData(response)
+    }
+  }, [page, sendRequest, queryParams])
+
+  useEffect(() => {
+    fetchExams()
+  }, [fetchExams])
+
+  // 검색 버튼 클릭
+  const handleSearch = () => {
+    setPage(1)
+    setQueryParams((prev) => ({
+      ...prev,
+      search_keyword: searchText,
+    }))
+  }
+
+  // 검색 인풋 엔터키
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch()
+    }
+  }
+
+  // 필터 적용 버튼
   const handleSubmitFilter = () => {
+    setPage(1)
+    setQueryParams((prev) => ({
+      ...prev,
+      subject_id: filterValues['subject_id'],
+    }))
     handleCloseFilter()
   }
 
@@ -73,8 +113,16 @@ export function ExamListPage() {
               <Input
                 placeholder="검색어를 입력하세요"
                 className="h-9 w-[250px]"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                onKeyDown={handleKeyDown}
               />
-              <Button variant="search" size="search" className="flex-shrink-0">
+              <Button
+                variant="search"
+                size="search"
+                className="flex-shrink-0"
+                onClick={handleSearch}
+              >
                 조회
               </Button>
             </div>


### PR DESCRIPTION
## ✨ PR 개요
쪽지시험에 과정별 필터링 모달과 검색창에 조회 기능 추가

## 📌 관련 이슈
Closes #168 

## 🧩 작업 내용 (주요 변경사항)
- 검색 + 필터링 핸들링 시 바뀔 데이터를 추가하여 fetchExam할때 같이 보내어 값을 받아오도록 추가
- 과정별 필터링시에 default값인 "전체"를 선택하여도 cansubmit의 bool값을 변경 시켜주어 로직을 처리하도록 수정
- 조회된 값이 없을 때 빈 UI 처리

## 💬 리뷰 포인트


## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/8271e190-d34e-4bbc-86bd-b71025a5fb95


## 🧠 기타 참고사항
추후에 loading 추가 예정입니다. 빈 UI도 시간 가능하면 이쁘게 스타일링 할 예정입니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
