### PR TITLE
Refactor: 응시 목록 삭제 관련 수정 및 AdminContainer 레이아웃 조정

### DIFF
--- a/src/components/layout/AdminContainer.tsx
+++ b/src/components/layout/AdminContainer.tsx
@@ -15,7 +15,7 @@ export function AdminContainer({
     <div
       className={[
         'min-w-0',
-        'pt-1.5 pl-8',
+        'pt-3 pl-4',
         'overflow-x-auto',
         'overflow-y-auto',
         className,

--- a/src/hooks/useExamHistory.ts
+++ b/src/hooks/useExamHistory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { API_PATHS } from '@/constants/api'
 import type { HistoryItem, HistoryListResponse } from '@/types/history'
 import { useAxios } from './useAxios'
@@ -7,28 +7,29 @@ export function useExamHistory() {
   const { sendRequest, isLoading } = useAxios()
   const [submissions, setSubmissions] = useState<HistoryItem[]>([])
 
-  useEffect(() => {
-    const fetchExamHistory = async () => {
-      try {
-        const data = await sendRequest<HistoryListResponse>({
-          method: 'GET',
-          url: API_PATHS.SUBMISSIONS.LIST,
-          errorTitle: '응시 내역 조회에 실패했습니다.',
-        })
+  const refetch = useCallback(async () => {
+    try {
+      const data = await sendRequest<HistoryListResponse>({
+        method: 'GET',
+        url: API_PATHS.SUBMISSIONS.LIST,
+        errorTitle: '응시 내역 조회에 실패했습니다.',
+      })
 
-        if (data?.results) {
-          setSubmissions(data.results)
-        }
-      } catch {
-        // 에러는 useAxios에서 전역 에러 스토어로 처리
+      if (data?.results) {
+        setSubmissions(data.results)
       }
+    } catch {
+      // 에러는 useAxios에서 전역 에러 스토어로 처리
     }
-
-    void fetchExamHistory()
   }, [sendRequest])
+
+  useEffect(() => {
+    void refetch()
+  }, [refetch])
 
   return {
     submissions,
     isLoading,
+    refetch,
   }
 }

--- a/src/pages/exam-page/ExamHistoryPage.tsx
+++ b/src/pages/exam-page/ExamHistoryPage.tsx
@@ -14,7 +14,7 @@ import { useExamHistory } from '@/hooks'
 
 export function ExamHistoryPage() {
   const navigate = useNavigate()
-  const { submissions, isLoading } = useExamHistory()
+  const { submissions, isLoading, refetch } = useExamHistory()
   const [isFilterOpen, setIsFilterOpen] = useState(false)
   const [filter, setFilter] = useState<FilterValue>({
     course: '',
@@ -86,6 +86,7 @@ export function ExamHistoryPage() {
   }
 
   const handleDeleteConfirm = () => {
+    refetch()
     showToast({
       variant: 'success',
       message: '응시 내역 삭제가 완료되었습니다.',

--- a/src/pages/exam-page/FilteredExamHistoryPage.tsx
+++ b/src/pages/exam-page/FilteredExamHistoryPage.tsx
@@ -27,7 +27,7 @@ const EMPTY_FILTER: FilterValue = {
 export function FilteredExamHistoryPage() {
   const navigate = useNavigate()
   const location = useLocation()
-  const { submissions, isLoading } = useExamHistory()
+  const { submissions, isLoading, refetch } = useExamHistory()
   const locationState = location.state as LocationState | null
   const initialFilter = locationState?.filter ?? EMPTY_FILTER
   const isValidFilter = Boolean(
@@ -143,6 +143,7 @@ export function FilteredExamHistoryPage() {
   }
 
   const handleDeleteConfirm = () => {
+    refetch()
     showToast({
       variant: 'success',
       message: '응시 내역 삭제가 완료되었습니다.',


### PR DESCRIPTION
## ✨ PR 개요
응시 내역 삭제 시 목록이 즉시 갱신되도록 수정하고, AdminContainer 레이아웃 간격을 조정했습니다.

## 📌 관련 이슈
Closes #171 

## 🧩 작업 내용 (주요 변경사항)
- useExamHistory에 refetch 함수 추가
- AdminContainer 레이아웃 간격 조정

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/65ff56ab-0922-42ed-8195-73b36603ec8f" />

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료