### PR TITLE
feat: 회원 정보 수정 api 연결 (#179)

### DIFF
--- a/src/components/member-management/MemberDetailModal.tsx
+++ b/src/components/member-management/MemberDetailModal.tsx
@@ -31,7 +31,7 @@ type MemberDetailModalProps = {
   onClose: () => void
   member: Member | null
   onDeleteConfirm?: (member: Member) => void
-  onEdit?: () => void
+  onEdit?: (detail: MemberDetail) => void
   onPermissionConfirm?: () => void
 }
 
@@ -236,7 +236,7 @@ export function MemberDetailModal({
                   type="button"
                   variant="primary"
                   className="h-[36px] w-[55.13px] rounded-[3px]"
-                  onClick={onEdit}
+                  onClick={() => onEdit?.(detail)}
                 >
                   수정
                 </Button>

--- a/src/components/member-management/MemberDetailModal.tsx
+++ b/src/components/member-management/MemberDetailModal.tsx
@@ -109,9 +109,10 @@ export function MemberDetailModal({
     { label: '관리자', value: '관리자' },
   ]
 
-  const courseOptions: Option[] = Array.from(
-    new Set([...(detail.ongoingCourses ?? []), ...(detail.cohorts ?? [])])
-  ).map((c) => ({ label: c, value: c }))
+  const courseOptions: Option[] = (detail.ongoingCourses ?? []).map((c) => ({
+    label: c,
+    value: c,
+  }))
 
   const cohortOptions: Option[] = [
     { label: '11기', value: '11기' },

--- a/src/components/member-management/MemberDetailTable.tsx
+++ b/src/components/member-management/MemberDetailTable.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import type { MemberRole } from '@/types'
 import imgEditIcon from '@/assets/icons/ImgEdit.svg'
 
@@ -107,14 +107,23 @@ export function ProfileImageCell({
   showEditIcon?: boolean
   onEditClick?: () => void
 }) {
+  const [loadError, setLoadError] = useState(false)
+
+  useEffect(() => {
+    setLoadError(false)
+  }, [imageUrl])
+
+  const showImage = imageUrl && !loadError
+
   return (
     <TdCell rowSpan={4} className="overflow-hidden !p-0">
       <div className="bg-grey-100 relative h-[199px] w-[141px] overflow-hidden">
-        {imageUrl ? (
+        {showImage ? (
           <img
             src={imageUrl}
             alt={alt}
             className="block h-full w-full object-cover"
+            onError={() => setLoadError(true)}
           />
         ) : (
           <div

--- a/src/components/member-management/MemberEditModal.tsx
+++ b/src/components/member-management/MemberEditModal.tsx
@@ -55,8 +55,8 @@ const GENDER_OPTIONS: Option[] = [
   { label: '미설정', value: '미설정' },
 ]
 
-/** 닉네임 형식: 2~12자, 영문 소문자/숫자/밑줄만 */
-const NICKNAME_REGEX = /^[a-z0-9_]{2,12}$/
+/** 닉네임 형식: 2~12자, 영문 소문자/숫자/밑줄/한글 */
+const NICKNAME_REGEX = /^[a-z0-9_가-힣ㄱ-ㅎㅏ-ㅣ]{2,12}$/
 const isValidNicknameFormat = (s: string) => NICKNAME_REGEX.test(s.trim())
 
 const normalizeDateValue = (value?: string) => {
@@ -118,7 +118,7 @@ export function MemberEditModal({
     if (!trimmed) return ''
     if (isNicknameDuplicate) return '이미 존재하는 닉네임입니다.'
     if (!isValidNicknameFormat(value.nickname))
-      return '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)만 사용할 수 있어요.'
+      return '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)/한글만 사용할 수 있어요.'
     return ''
   }, [value.nickname, isNicknameDuplicate])
 
@@ -234,7 +234,7 @@ export function MemberEditModal({
                                 )}
                               >
                                 {nicknameError ||
-                                  '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)만 사용할 수 있어요.'}
+                                  '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)/한글만 사용할 수 있어요.'}
                               </div>
                             </div>
                           </div>

--- a/src/components/member-management/MemberEditModal.tsx
+++ b/src/components/member-management/MemberEditModal.tsx
@@ -12,6 +12,7 @@ import { MOCK_MEMBER_LIST_RESPONSE } from '@/mocks/data/table-data/MemberList'
 import nicknameOverlapAlert from '@/assets/icons/NicknameOverlapAlert.svg'
 import { inputVariants } from '@/constants/variants'
 import { cn } from '@/lib/cn'
+import { formatDateTime } from '@/utils/dateUtils'
 import {
   TableWrap,
   TableRow,
@@ -299,7 +300,7 @@ export function MemberEditModal({
 
               <TableRow>
                 <ThCell>가입일</ThCell>
-                <TdCell colSpan={4}>{detail.joinedAt}</TdCell>
+                <TdCell colSpan={4}>{formatDateTime(detail.joinedAt)}</TdCell>
               </TableRow>
 
               <TableRow>

--- a/src/components/member-management/MemberEditModal.tsx
+++ b/src/components/member-management/MemberEditModal.tsx
@@ -55,6 +55,10 @@ const GENDER_OPTIONS: Option[] = [
   { label: '미설정', value: '미설정' },
 ]
 
+/** 닉네임 형식: 2~12자, 영문 소문자/숫자/밑줄만 */
+const NICKNAME_REGEX = /^[a-z0-9_]{2,12}$/
+const isValidNicknameFormat = (s: string) => NICKNAME_REGEX.test(s.trim())
+
 const normalizeDateValue = (value?: string) => {
   if (!value) return ''
   return value.includes('.') ? value.replace(/\./g, '-') : value
@@ -78,7 +82,6 @@ export function MemberEditModal({
     cohort: '',
     birthDate: '',
   })
-  const [nicknameError, setNicknameError] = useState('')
   const [isNicknameFocused, setIsNicknameFocused] = useState(false)
   const imageInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -105,9 +108,19 @@ export function MemberEditModal({
     )
   }, [value.nickname, detail?.nickname])
 
-  useEffect(() => {
-    setNicknameError(isNicknameDuplicate ? '이미 존재하는 닉네임입니다.' : '')
-  }, [isNicknameDuplicate])
+  const isValidNickname = useMemo(
+    () => isValidNicknameFormat(value.nickname) && !isNicknameDuplicate,
+    [value.nickname, isNicknameDuplicate]
+  )
+
+  const nicknameError = useMemo(() => {
+    const trimmed = value.nickname.trim()
+    if (!trimmed) return ''
+    if (isNicknameDuplicate) return '이미 존재하는 닉네임입니다.'
+    if (!isValidNicknameFormat(value.nickname))
+      return '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)만 사용할 수 있어요.'
+    return ''
+  }, [value.nickname, isNicknameDuplicate])
 
   const imageUrl = detail?.profileImageUrl ?? DEFAULT_MEMBER_IMAGE_URL
   const openImagePicker = () => imageInputRef.current?.click()
@@ -196,39 +209,36 @@ export function MemberEditModal({
                         onBlur={() => setIsNicknameFocused(false)}
                         className={cn(
                           inputVariants({
-                            status:
-                              nicknameError || isNicknameFocused
-                                ? 'error'
-                                : 'default',
+                            status: nicknameError ? 'error' : 'default',
                             size: 'sm',
                             className: 'pr-10',
                           }),
                           'pl-3'
                         )}
                       />
-                      {(isNicknameFocused || nicknameError) && (
-                        <div className="absolute top-1/2 right-3 -translate-y-1/2">
-                          <div className="relative">
-                            <img
-                              src={nicknameOverlapAlert}
-                              alt="닉네임 안내"
-                              className="h-4 w-4"
-                            />
-                            <div
-                              className={cn(
-                                'absolute right-0 bottom-full z-10 mb-2 w-[260px] rounded-md border bg-white px-3 py-2 text-xs shadow-sm',
-                                isNicknameFocused || nicknameError
-                                  ? 'border-error-400 text-error-400'
-                                  : 'border-grey-200 text-grey-700'
-                              )}
-                            >
-                              {nicknameError
-                                ? nicknameError
-                                : '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)만 사용할 수 있어요.'}
+                      {(isNicknameFocused || nicknameError) &&
+                        !isValidNickname && (
+                          <div className="absolute top-1/2 right-3 -translate-y-1/2">
+                            <div className="relative">
+                              <img
+                                src={nicknameOverlapAlert}
+                                alt="닉네임 안내"
+                                className="h-4 w-4"
+                              />
+                              <div
+                                className={cn(
+                                  'absolute right-0 bottom-full z-10 mb-2 w-[260px] rounded-md border bg-white px-3 py-2 text-xs shadow-sm',
+                                  nicknameError
+                                    ? 'border-error-400 text-error-400'
+                                    : 'border-grey-200 text-grey-700'
+                                )}
+                              >
+                                {nicknameError ||
+                                  '닉네임은 2~12자, 영문 소문자/숫자/밑줄(_)만 사용할 수 있어요.'}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      )}
+                        )}
                     </div>
                   </div>
                 </TdCell>

--- a/src/components/table/MemberList.tsx
+++ b/src/components/table/MemberList.tsx
@@ -3,6 +3,7 @@ import { MemberStatusBadge, Pagination } from '@/components/common'
 import { DataTable, type Column } from './data-table/DataTable'
 import type { Member } from '@/types/member'
 import { RoleLabel } from '@/components/member-management/MemberDetailTable'
+import { formatDateTime } from '@/utils/dateUtils'
 
 type MemberListProps = {
   data: Member[]
@@ -94,7 +95,7 @@ const MEMBER_COLUMNS = (
     key: 'joinedAt',
     title: '가입일',
     size: 'xl',
-    cell: (item) => item.joinedAt,
+    cell: (item) => formatDateTime(item.joinedAt),
   },
 ]
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw'
+import { adminAccountHandlers } from './handlers/adminAccountHandlers'
 import { examGraphHandlers } from './handlers/examGraphHandlers'
 import { memberGraphHandlers } from './handlers/memberGraphHandlers'
 import { withdrawalHandlers } from './handlers/withdrawalHandlers'
@@ -10,6 +11,7 @@ const testHandler = http.get('/api/hello', () => {
 
 export const handlers = [
   testHandler,
+  ...adminAccountHandlers,
   ...examDeploymentHandlers,
   ...examGraphHandlers,
   ...memberGraphHandlers,

--- a/src/mocks/handlers/adminAccountHandlers.ts
+++ b/src/mocks/handlers/adminAccountHandlers.ts
@@ -1,0 +1,20 @@
+import { http, HttpResponse } from 'msw'
+import { API_PATHS } from '@/constants/api'
+
+export const adminAccountHandlers = [
+  http.patch(
+    `*${API_PATHS.ACCOUNTS.DETAIL(':id')}`,
+    async ({ params, request }) => {
+      const { id } = params as { id: string }
+      const body = (await request.json()) as Record<string, unknown>
+
+      return HttpResponse.json(
+        {
+          id: Number(id),
+          ...body,
+        },
+        { status: 200 }
+      )
+    }
+  ),
+]

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -10,6 +10,7 @@ import type { DropdownOption } from '@/types/commonComponents'
 import { useToastStore } from '@/store'
 
 const ROLE_OPTIONS: DropdownOption[] = [
+  { label: '전체', value: 'ALL' },
   { label: 'Admin', value: 'Admin' },
   { label: 'Staff (TA)', value: 'Staff (TA)' },
   { label: 'Student', value: 'Student' },
@@ -19,6 +20,7 @@ const ROLE_OPTIONS: DropdownOption[] = [
 ]
 
 const STATUS_OPTIONS: DropdownOption[] = [
+  { label: '전체', value: 'ALL' },
   { label: 'Activated', value: 'Activated' },
   { label: 'Disabled', value: 'Disabled' },
   { label: 'Withdraw', value: 'Withdraw' },
@@ -40,8 +42,10 @@ export default function ManagementPage({
   externalLoading,
 }: ManagementPageProps) {
   const showRoleFilter = listVariant === 'member'
-  const [roleInput, setRoleInput] = useState<MemberRole | undefined>()
-  const [statusInput, setStatusInput] = useState<Member['status'] | undefined>()
+  const [roleInput, setRoleInput] = useState<MemberRole | 'ALL'>('ALL')
+  const [statusInput, setStatusInput] = useState<Member['status'] | 'ALL'>(
+    'ALL'
+  )
   const [keywordInput, setKeywordInput] = useState('')
   const [role, setRole] = useState<'ALL' | MemberRole>('ALL')
   const [status, setStatus] = useState<'ALL' | Member['status']>('ALL')
@@ -178,7 +182,11 @@ export default function ManagementPage({
                   placeholder="권한"
                   options={ROLE_OPTIONS}
                   value={roleInput}
-                  onChange={(v) => setRoleInput(v as MemberRole)}
+                  onChange={(v) => {
+                    const val = v as MemberRole | 'ALL'
+                    setRoleInput(val)
+                    setRole(val)
+                  }}
                 />
               </div>
             )}
@@ -190,7 +198,11 @@ export default function ManagementPage({
                 placeholder="회원 상태"
                 options={STATUS_OPTIONS}
                 value={statusInput}
-                onChange={(v) => setStatusInput(v as Member['status'])}
+                onChange={(v) => {
+                  const val = v as Member['status'] | 'ALL'
+                  setStatusInput(val)
+                  setStatus(val)
+                }}
               />
             </div>
 

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -4,7 +4,7 @@ import { MemberDetailModal } from '@/components/member-management/MemberDetailMo
 import { MemberEditModal } from '@/components/member-management/MemberEditModal'
 import { MemberManagementLayout } from '@/components/layout'
 import MemberList from '@/components/table/MemberList'
-import type { Member, MemberRole } from '@/types'
+import type { Member, MemberDetail, MemberRole } from '@/types'
 import { MOCK_MEMBER_DETAIL_MAP } from '@/mocks/data/member-detail'
 import type { DropdownOption } from '@/types/commonComponents'
 import { useToastStore } from '@/store'
@@ -53,6 +53,7 @@ export default function ManagementPage({
   const [detailOpen, setDetailOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
   const [selectedMember, setSelectedMember] = useState<Member | null>(null)
+  const [editDetail, setEditDetail] = useState<MemberDetail | null>(null)
   const [memberList, setMemberList] = useState(listData)
   const showToast = useToastStore((state) => state.showToast)
   const [internalLoading, setInternalLoading] = useState(
@@ -77,6 +78,12 @@ export default function ManagementPage({
     setStatus(statusInput ?? 'ALL')
     setKeyword(keywordInput)
   }
+
+  useEffect(() => {
+    if (keywordInput.trim() === '') {
+      setKeyword('')
+    }
+  }, [keywordInput])
 
   const filtered = useMemo(() => {
     const kw = keyword.trim().toLowerCase()
@@ -106,14 +113,15 @@ export default function ManagementPage({
     setSelectedMember(null)
   }
 
-  const openMemberEdit = () => {
-    if (!selectedMember) return
+  const openMemberEdit = (detail: MemberDetail) => {
+    setEditDetail(detail)
     setDetailOpen(false)
     setEditOpen(true)
   }
 
   const closeMemberEdit = () => {
     setEditOpen(false)
+    setEditDetail(null)
   }
 
   const handleDeleteConfirm = (member: Member) => {
@@ -249,7 +257,7 @@ export default function ManagementPage({
           <MemberEditModal
             open={editOpen}
             onClose={closeMemberEdit}
-            detail={selectedDetail}
+            detail={editDetail ?? selectedDetail}
             courseOptions={courseOptions}
             cohortOptions={cohortOptions}
             onSave={handleEditSave}

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -142,6 +142,13 @@ export default function ManagementPage({
     })
   }
 
+  const handlePermissionConfirm = () => {
+    showToast({
+      variant: 'success',
+      message: '권한이 성공적으로 변경되었습니다.',
+    })
+  }
+
   const selectedDetail = useMemo(() => {
     if (!selectedMember) return null
     const detail = MOCK_MEMBER_DETAIL_MAP[selectedMember.id] ?? {
@@ -252,6 +259,7 @@ export default function ManagementPage({
             member={selectedMember}
             onDeleteConfirm={handleDeleteConfirm}
             onEdit={openMemberEdit}
+            onPermissionConfirm={handlePermissionConfirm}
           />
 
           <MemberEditModal

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -170,8 +170,19 @@ export type AdminAccountListResponse = {
 
 /** GET /api/v1/admin/accounts/{id}/ 상세 응답 (retrieve) */
 export type AssignedCourseItem = {
-  course?: string | { id?: number; name?: string; course_name?: string }
-  cohort?: number | { id?: number; number?: number }
+  course?:
+    | string
+    | { id?: number; name?: string; course_name?: string; tag?: string }
+  cohort?:
+    | number
+    | {
+        id?: number
+        number?: number
+        status?: string
+        status_display?: string
+        start_date?: string
+        end_date?: string
+      }
   course_name?: string
 }
 export type AdminAccountDetail = AdminAccountListItem & {


### PR DESCRIPTION
## ✨ PR 개요
- 회원 관리 페이지와 관련 모달을 개선했습니다.
- 수정 모달에 API 상세 데이터(프로필 이미지)를 연동하고, 닉네임 검증에 한글 지원을 추가하며, 권한 변경 모달 옵션 및 UX를 수정했습니다.

## 📌 관련 이슈
Closes #179 

## 🧩 작업 내용 (주요 변경사항)
- 영문 소문자/숫자/밑줄에 한글 지원 추가
- 권한 변경 저장 시 성공 토스트 표시

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료