### PR TITLE
feat: 수강생 관리 api 연동 (#193)

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -29,6 +29,9 @@ export const API_PATHS = {
     SUBJECT_SCATTER: (subjectId: number | string) =>
       `api/v1/admin/subjects/${subjectId}/scatter`,
   },
+  STUDENTS: {
+    LIST: '/api/v1/admin/students/',
+  },
   MEMBER: {
     STUDENT_REGISTRATION: '/api/v1/admin/student-enrollments/',
     STUDENT_REGISTRATION_ACCEPT: '/api/v1/admin/student-enrollments/accept',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useAdminAccountDetail'
 export * from './useAdminAccounts'
+export * from './useAdminStudents'
 export * from './useAxios'
 export * from './useFilter'
 export * from './useExamUpload'

--- a/src/hooks/useAdminStudents.ts
+++ b/src/hooks/useAdminStudents.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import { API_PATHS } from '@/constants/api'
+import type {
+  AdminStudentListResponse,
+  AdminStudentListItem,
+  Member,
+} from '@/types/member'
+import { useAxios } from './useAxios'
+import { mapApiStatusToMemberStatus } from '@/utils/accountMapping'
+
+const DEFAULT_PAGE_SIZE = 20
+
+function getCourseName(item: AdminStudentListItem): string | undefined {
+  if (item.course_name) return item.course_name
+  if (item.course?.name) return item.course.name
+  const first = item.assigned_courses?.[0]
+  if (first?.course_name) return first.course_name
+  if (first?.course?.name) return first.course.name
+  return undefined
+}
+
+function getCohortDisplay(item: AdminStudentListItem): string | undefined {
+  if (item.cohort_number != null) return `${item.cohort_number}기`
+  if (item.cohort?.number != null) return `${item.cohort.number}기`
+  const first = item.assigned_courses?.[0]
+  const c = first?.cohort
+  if (typeof c === 'number') return `${c}기`
+  if (c?.number != null) return `${c.number}기`
+  return undefined
+}
+
+function mapStudentToMember(item: AdminStudentListItem): Member {
+  const u = item.user
+
+  return {
+    id: u?.id ?? item.id ?? 0,
+    nickname: item.nickname ?? u?.nickname ?? '',
+    name: item.name ?? u?.name ?? '-',
+    email: item.email ?? u?.email ?? '',
+    phone: item.phone_number ?? (u as { phone_number?: string })?.phone_number,
+    birthDate: item.birthday ?? (u as { birthday?: string })?.birthday ?? '-',
+    role: 'Student',
+    status: mapApiStatusToMemberStatus(item.status),
+    joinedAt: item.created_at ?? '-',
+    course: getCourseName(item),
+    cohort: getCohortDisplay(item),
+  }
+}
+
+export type UseAdminStudentsOptions = {
+  cohort_id?: number
+  status?: string
+  search?: string
+  page?: number
+  page_size?: number
+}
+
+export function useAdminStudents(options?: UseAdminStudentsOptions) {
+  const { sendRequest, isLoading } = useAxios()
+  const [members, setMembers] = useState<Member[]>([])
+  const [totalCount, setTotalCount] = useState(0)
+
+  const cohortId = options?.cohort_id
+  const status = options?.status
+  const search = options?.search
+  const page = options?.page ?? 1
+  const pageSize = options?.page_size ?? DEFAULT_PAGE_SIZE
+
+  useEffect(() => {
+    const fetchStudents = async () => {
+      const params: Record<string, string | number> = {
+        page,
+        page_size: pageSize,
+      }
+      if (cohortId != null) params.cohort_id = cohortId
+      if (status) params.status = status.toLowerCase()
+      if (search) params.search = search
+
+      try {
+        const data = await sendRequest<AdminStudentListResponse>({
+          method: 'GET',
+          url: API_PATHS.STUDENTS.LIST,
+          params,
+          errorTitle: '수강생 목록 조회에 실패했습니다.',
+        })
+
+        if (data?.results) {
+          setMembers(data.results.map(mapStudentToMember))
+          setTotalCount(data.count ?? data.results.length)
+        } else {
+          setMembers([])
+          setTotalCount(0)
+        }
+      } catch {
+        setMembers([])
+        setTotalCount(0)
+      }
+    }
+
+    void fetchStudents()
+  }, [sendRequest, cohortId, status, search, page, pageSize])
+
+  return {
+    members,
+    totalCount,
+    isLoading,
+  }
+}

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -26,13 +26,32 @@ const STATUS_OPTIONS: DropdownOption[] = [
   { label: 'Withdraw', value: 'Withdraw' },
 ]
 
+type StudentSearchFilters = {
+  cohort_id?: number
+  status?: string
+  keyword?: string
+}
+
 type ManagementPageProps = {
   title: string
   listVariant: 'member' | 'student'
   listData: Member[]
   enableDetail?: boolean
   externalLoading?: boolean
+  /** 수강생: 기수 옵션 및 조회 시 API refetch 콜백 */
+  studentCohortOptions?: DropdownOption[]
+  onStudentSearch?: (filters: StudentSearchFilters) => void
 }
+
+const STUDENT_COHORT_OPTIONS: DropdownOption[] = [
+  { label: '전체', value: '' },
+  { label: '10기', value: '10' },
+  { label: '11기', value: '11' },
+  { label: '12기', value: '12' },
+  { label: '13기', value: '13' },
+  { label: '14기', value: '14' },
+  { label: '15기', value: '15' },
+]
 
 export default function ManagementPage({
   title,
@@ -40,8 +59,15 @@ export default function ManagementPage({
   listData,
   enableDetail = true,
   externalLoading,
+  studentCohortOptions = listVariant === 'student'
+    ? STUDENT_COHORT_OPTIONS
+    : undefined,
+  onStudentSearch,
 }: ManagementPageProps) {
   const showRoleFilter = listVariant === 'member'
+  const showCohortFilter =
+    listVariant === 'student' && studentCohortOptions?.length
+  const [cohortInput, setCohortInput] = useState('')
   const [roleInput, setRoleInput] = useState<MemberRole | 'ALL'>('ALL')
   const [statusInput, setStatusInput] = useState<Member['status'] | 'ALL'>(
     'ALL'
@@ -77,6 +103,16 @@ export default function ManagementPage({
     setRole(roleInput ?? 'ALL')
     setStatus(statusInput ?? 'ALL')
     setKeyword(keywordInput)
+    if (showCohortFilter && onStudentSearch) {
+      const cohortId = cohortInput ? Number(cohortInput) : undefined
+      const statusVal =
+        statusInput && statusInput !== 'ALL' ? statusInput : undefined
+      onStudentSearch({
+        cohort_id: cohortId,
+        status: statusVal,
+        keyword: keywordInput.trim() || undefined,
+      })
+    }
   }
 
   useEffect(() => {
@@ -189,6 +225,18 @@ export default function ManagementPage({
         title={title}
         toolbar={
           <>
+            {showCohortFilter && studentCohortOptions && (
+              <div className="w-[100px]">
+                <Dropdown
+                  variant="memberFilter"
+                  size="sm"
+                  placeholder="기수"
+                  options={studentCohortOptions}
+                  value={cohortInput}
+                  onChange={(v) => setCohortInput(v ?? '')}
+                />
+              </div>
+            )}
             {showRoleFilter && (
               <div className="w-[140px]">
                 <Dropdown

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -118,8 +118,24 @@ export default function ManagementPage({
   useEffect(() => {
     if (keywordInput.trim() === '') {
       setKeyword('')
+      if (showCohortFilter && onStudentSearch) {
+        const cohortId = cohortInput ? Number(cohortInput) : undefined
+        const statusVal =
+          statusInput && statusInput !== 'ALL' ? statusInput : undefined
+        onStudentSearch({
+          cohort_id: cohortId,
+          status: statusVal,
+          keyword: undefined,
+        })
+      }
     }
-  }, [keywordInput])
+  }, [
+    keywordInput,
+    showCohortFilter,
+    onStudentSearch,
+    cohortInput,
+    statusInput,
+  ])
 
   const filtered = useMemo(() => {
     const kw = keyword.trim().toLowerCase()

--- a/src/pages/member-management/StudentManagementPage.tsx
+++ b/src/pages/member-management/StudentManagementPage.tsx
@@ -1,17 +1,34 @@
+import { useCallback, useState } from 'react'
 import ManagementPage from './ManagementPage'
-import { MOCK_MEMBER_LIST_RESPONSE } from '@/mocks/data/table-data/MemberList'
+import { useAdminStudents } from '@/hooks'
+
+type StudentFilters = {
+  cohort_id?: number
+  status?: string
+  keyword?: string
+}
 
 export function StudentManagementPage() {
-  const studentList = MOCK_MEMBER_LIST_RESPONSE.members.filter(
-    (member) => member.role === 'Student'
-  )
+  const [filters, setFilters] = useState<StudentFilters>({})
+
+  const { members, isLoading } = useAdminStudents({
+    cohort_id: filters.cohort_id,
+    status: filters.status,
+    search: filters.keyword,
+  })
+
+  const handleStudentSearch = useCallback((next: StudentFilters) => {
+    setFilters(next)
+  }, [])
 
   return (
     <ManagementPage
       title="수강생 관리"
       listVariant="student"
-      listData={studentList}
+      listData={members}
       enableDetail={false}
+      externalLoading={isLoading}
+      onStudentSearch={handleStudentSearch}
     />
   )
 }

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -148,6 +148,53 @@ export interface PaginatedWithdrawalResponse<T> {
   results: T[]
 }
 
+/** GET /api/v1/admin/students/ 쿼리 파라미터 */
+export type AdminStudentsQuery = {
+  cohort_id?: number
+  status?: string
+  search?: string
+  page?: number
+  page_size?: number
+}
+
+/** GET /api/v1/admin/students/ 응답 항목 (enrollment 또는 user 스타일 지원) */
+export type AdminStudentListItem = {
+  id: number
+  email?: string
+  nickname?: string
+  name?: string
+  phone_number?: string
+  birthday?: string
+  status?: string
+  created_at?: string
+  user?: {
+    id: number
+    email: string
+    name?: string
+    nickname?: string
+    birthday?: string
+    phone_number?: string
+  }
+  cohort?: { id: number; number: number }
+  course?: { id: number; name: string; tag?: string }
+  /** flat 필드 (API 스키마에 따라 다름) */
+  course_name?: string
+  cohort_number?: number
+  /** 수강 중인 과정 목록 (assigned_courses 등) */
+  assigned_courses?: Array<{
+    course?: { id?: number; name?: string }
+    course_name?: string
+    cohort?: number | { id?: number; number?: number }
+  }>
+}
+
+export type AdminStudentListResponse = {
+  count: number
+  next: string | null
+  previous: string | null
+  results: AdminStudentListItem[]
+}
+
 // GET /api/v1/admin/accounts/ 응답 항목 (200 예제값·스키마 기준)
 export type AdminAccountListItem = {
   id: number


### PR DESCRIPTION
## ✨ PR 개요
- 수강생 관리 페이지에 `/api/v1/admin/students/` API를 연동했습니다.
- Mock 데이터를 제거하고 실제 API로 수강생 목록을 조회하며, 기수/상태 필터와 검색어 초기화 시 목록 재조회 기능을 추가했습니다.

## 📌 관련 이슈
Closes #193

## 🧩 작업 내용 (주요 변경사항)
- 파라미터로 수강생 목록 API 조회
- `Member` 타입으로 매핑
- 수강생 모드에서 기수 드롭다운 노출

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/0cdab1d9-f20f-47ba-8069-dc1b9dcfda14

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료