### PR TITLE
feat: 쪽지시험 목록 조회 페이지와 상세 문제 페이지에 skeleton 적용 (#190)

### DIFF
--- a/src/pages/exam-page/exam-list/DetailExamPage.tsx
+++ b/src/pages/exam-page/exam-list/DetailExamPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { DetailExamContainer } from '@/components/detail-exam'
 import ExamModal from '@/components/detail-exam/exam-modal/ExamModal'
-import { AlertModal, Button } from '@/components/common'
+import { AlertModal, Button, TableSkeleton } from '@/components/common'
 import { ExamHistoryLayout } from '@/components/layout'
 import { useAxios } from '@/hooks'
 import { API_PATHS } from '@/constants/api'
@@ -60,18 +60,6 @@ export function DetailExamPage() {
     }
   }
 
-  if (isLoading && !data) {
-    return (
-      <ExamHistoryLayout title="쪽지시험 상세조회">
-        <div className="text-grey-500 flex h-60 items-center justify-center">
-          로딩 중...
-        </div>
-      </ExamHistoryLayout>
-    )
-  }
-
-  if (!data) return null
-
   return (
     <>
       <ExamHistoryLayout
@@ -82,6 +70,7 @@ export function DetailExamPage() {
               variant="success"
               onClick={() => setIsModalOpen(true)}
               className={BUTTON_STYLE}
+              disabled={isLoading || !data}
             >
               수정
             </Button>
@@ -89,27 +78,34 @@ export function DetailExamPage() {
               variant="danger"
               onClick={() => setIsDeleteModalOpen(true)}
               className={BUTTON_STYLE}
+              disabled={isLoading || !data}
             >
               삭제
             </Button>
           </div>
         }
       >
-        <DetailExamContainer data={data} onSuccess={fetchDetail} />
+        {isLoading && !data ? (
+          <TableSkeleton rows={1} rowHeight={700} />
+        ) : (
+          data && <DetailExamContainer data={data} onSuccess={fetchDetail} />
+        )}
       </ExamHistoryLayout>
 
-      <ExamModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        mode="edit"
-        id={id}
-        onSuccess={fetchDetail}
-        initialData={{
-          title: data.title,
-          subject_id: data.subject.id,
-          logo_url: data.thumbnail_img_url,
-        }}
-      />
+      {data && (
+        <ExamModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          mode="edit"
+          id={id}
+          onSuccess={fetchDetail}
+          initialData={{
+            title: data.title,
+            subject_id: data.subject.id,
+            logo_url: data.thumbnail_img_url,
+          }}
+        />
+      )}
 
       <AlertModal
         isOpen={isDeleteModalOpen}

--- a/src/pages/exam-page/exam-list/ExamListPage.tsx
+++ b/src/pages/exam-page/exam-list/ExamListPage.tsx
@@ -4,6 +4,7 @@ import {
   FilterModal,
   Input,
   Pagination,
+  TableSkeleton,
 } from '@/components/common'
 import { ExamListLayout } from '@/components/layout'
 import AdminExamList from '@/components/table/AdminExamList'
@@ -122,6 +123,7 @@ export function ExamListPage() {
                 size="search"
                 className="flex-shrink-0"
                 onClick={handleSearch}
+                disabled={isLoading || !data}
               >
                 조회
               </Button>
@@ -151,9 +153,7 @@ export function ExamListPage() {
         }
       >
         {isLoading ? (
-          <div className="flex h-60 items-center justify-center">
-            데이터를 불러오는 중입니다...
-          </div>
+          <TableSkeleton rows={10} />
         ) : paginatedData.length === 0 ? (
           <div className="flex h-60 items-center justify-center">
             존재하는 데이터가 없습니다.


### PR DESCRIPTION
## ✨ PR 개요
쪽지시험 목록 조회 페이지 - ExamListPage 와 쪽지시험 상세 문제 페이지 - DetailExamPage 에 Skeleton UI 적용

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #190 

## 🧩 작업 내용 (주요 변경사항)
- isLoading 상태에 따라서 TableSkeleton를 출력
- isLoading 상태에 따라서 검색 및 조회 버튼은 그동안 비활성화 처리

## 📸 스크린샷 (선택)
<img width="1903" height="947" alt="image" src="https://github.com/user-attachments/assets/6e5cfe56-f69e-4db2-bbac-5dbe05a49d62" />

<img width="1903" height="942" alt="image" src="https://github.com/user-attachments/assets/2e18d497-a841-426a-a4ee-8fca848756d3" />

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
