### PR TITLE
fix: 문제 배점 옵션 수정 (#199)

### DIFF
--- a/src/components/detail-exam/problem-modal/problem-forms/common-sections/PointSection.tsx
+++ b/src/components/detail-exam/problem-modal/problem-forms/common-sections/PointSection.tsx
@@ -17,8 +17,6 @@ export function PointSection({
         options={[
           { label: '5', value: '5' },
           { label: '10', value: '10' },
-          { label: '15', value: '15' },
-          { label: '20', value: '20' },
         ]}
         value={String(value)}
         onChange={(v) => onChange(Number(v))}


### PR DESCRIPTION




## ✨ PR 개요
문제 배점 옵션을 5, 10, 15, 20 에서 5, 10 만 선택할 수 있도록 조정하였습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #199

## 🧩 작업 내용 (주요 변경사항)
- 문제 배점 옵션을 5점, 10점 선택할 수 있게 변경


## 📸 스크린샷 (선택)

<img width="95" height="160" alt="image" src="https://github.com/user-attachments/assets/380fd93d-75ce-42fe-98f2-e212c8a8af8e" />


## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
