### PR TITLE
feat: 쪽지시험 상세보기 모달 내 풀이보기 api 연동 (#196)

### DIFF
--- a/src/components/exam-attempt/ExamAttemptDetailModal.tsx
+++ b/src/components/exam-attempt/ExamAttemptDetailModal.tsx
@@ -96,7 +96,9 @@ export function ExamAttemptDetailModal({
     const d = detail as ExamSubmissionDetail | null
     const t = d?.elapsed_time
     if (t == null || t < 0) return '-'
-    return `${t}분`
+    const min = Math.floor(t / 60)
+    const sec = t % 60
+    return `${min}분 ${sec}초`
   }, [detail])
 
   useEffect(() => {

--- a/src/components/exam-attempt/ExamAttemptDetailModal.tsx
+++ b/src/components/exam-attempt/ExamAttemptDetailModal.tsx
@@ -69,7 +69,8 @@ export function ExamAttemptDetailModal({
   const { sendRequest } = useAxios()
 
   const submissionId = item?.submission_id ?? null
-  const { detail, isLoading } = useExamHistoryDetail(submissionId)
+  const { detail, questionsData, pickedAnswers, isLoading } =
+    useExamHistoryDetail(submissionId)
 
   const target = detail ?? item
 
@@ -152,7 +153,10 @@ export function ExamAttemptDetailModal({
                 <h3 className="text-grey-800 mb-0 text-sm font-bold">
                   쪽지시험 정보
                 </h3>
-                <SolutionViewTrigger />
+                <SolutionViewTrigger
+                  data={questionsData}
+                  pickedAnswerByQuestionId={pickedAnswers ?? undefined}
+                />
               </div>
 
               <TableWrap>

--- a/src/hooks/useAdminStudents.ts
+++ b/src/hooks/useAdminStudents.ts
@@ -13,6 +13,8 @@ const DEFAULT_PAGE_SIZE = 20
 function getCourseName(item: AdminStudentListItem): string | undefined {
   if (item.course_name) return item.course_name
   if (item.course?.name) return item.course.name
+  if (item.in_progress_course?.course?.name)
+    return item.in_progress_course.course.name
   const first = item.assigned_courses?.[0]
   if (first?.course_name) return first.course_name
   if (first?.course?.name) return first.course.name
@@ -22,6 +24,8 @@ function getCourseName(item: AdminStudentListItem): string | undefined {
 function getCohortDisplay(item: AdminStudentListItem): string | undefined {
   if (item.cohort_number != null) return `${item.cohort_number}기`
   if (item.cohort?.number != null) return `${item.cohort.number}기`
+  if (item.in_progress_course?.cohort?.number != null)
+    return `${item.in_progress_course.cohort.number}기`
   const first = item.assigned_courses?.[0]
   const c = first?.cohort
   if (typeof c === 'number') return `${c}기`

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -12,6 +12,21 @@ export interface HistoryItem {
   finished_at: string
 }
 
+/** API 응답 - 개별 문제 항목 */
+export interface ExamSubmissionQuestionApi {
+  id: number
+  number: number
+  type: string
+  question: string
+  prompt: string | null
+  options: string[]
+  point: number
+  answer: string | string[]
+  submitted_answer: string | string[]
+  is_correct: boolean
+  explanation: string
+}
+
 /** API 상세 응답 - exam/student/result 중첩 구조 */
 export interface ExamSubmissionDetailApi {
   exam?: {
@@ -34,7 +49,7 @@ export interface ExamSubmissionDetailApi {
     cheating_count?: number
     elapsed_time?: number
   }
-  questions?: unknown[]
+  questions?: ExamSubmissionQuestionApi[]
 }
 
 /** 상세 모달용 확장 - API 상세 응답 매핑 결과 */

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -166,6 +166,7 @@ export type AdminStudentListItem = {
   phone_number?: string
   birthday?: string
   status?: string
+  role?: string
   created_at?: string
   user?: {
     id: number
@@ -177,6 +178,11 @@ export type AdminStudentListItem = {
   }
   cohort?: { id: number; number: number }
   course?: { id: number; name: string; tag?: string }
+  /** in_progress_course 래퍼 (실제 API 응답 구조) */
+  in_progress_course?: {
+    cohort?: { id: number; number: number }
+    course?: { id: number; name: string; tag?: string }
+  }
   /** flat 필드 (API 스키마에 따라 다름) */
   course_name?: string
   cohort_number?: number


### PR DESCRIPTION
## ✨ PR 개요
수강생 관리 과정/기수 표시 수정, 쪽지시험 응시 상세 풀이보기 API 연동, 응시시간 단위 환산 수정

## 📌 관련 이슈
Closes #196 

## 🧩 작업 내용 (주요 변경사항)
- 응시시간이 초 단위로 내려오는걸 분과 초 형식으로 환산하도록 수정
- 풀이보기에 questions 데이터 연결 완료
- 수강생 관리 페이지에 과정/기수 데이터 연결 완료

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료