### PR TITLE
feat: app.tsx index 라우팅 로직 추가 (#206)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   GlobalToast,
   ErrorCatcher,
 } from '@/components/common'
+import { useAuthStore } from '@/store'
 import { LoginPage } from '@/pages/login'
 import {
   DetailExamPage,
@@ -24,14 +25,22 @@ import {
 import { NotFoundPage } from '@/pages/not-found'
 
 export default function App() {
+  const accessToken = useAuthStore((state) => state.accessToken)
+
   return (
     <>
       <Routes>
-        <Route path="/login" element={<LoginPage />} />
+        <Route path="login" element={<LoginPage />} />
         <Route element={<AdminLayout />}>
           <Route
             index
-            element={<Navigate to="/members/management" replace />}
+            element={
+              accessToken ? (
+                <Navigate to="/members/management" replace />
+              ) : (
+                <Navigate to="/login" replace />
+              )
+            }
           />
           <Route path="exam">
             <Route path="dashboard" element={<ExamDashboardPage />} />


### PR DESCRIPTION
## ✨ PR 개요
accessToken의 값을 통해 로그인한 유저인지 아닌지 로직을 추가해 navigate 위치를 변경하였습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #206

## 🧩 작업 내용 (주요 변경사항)
- accessToken을 받아와 메모리상에 accessToken을 확인하여 분기 처리 

## 💬 리뷰 포인트
이 로직이 괜찮을지... 초기에 로그인을 안한 사용자의 accessToken는 NULL 처리가 되어있습니다.
`  const accessToken = useAuthStore((state) => state.accessToken)`

```
          <Route
            index
            element={
              accessToken ? (
                <Navigate to="/members/management" replace />
              ) : (
                <Navigate to="/login" replace />
              )
            }
          />
```

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
