### PR TITLE
feat: externalLoading -> isLoading 적용 (#212)

### DIFF
--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -37,7 +37,7 @@ type ManagementPageProps = {
   listVariant: 'member' | 'student'
   listData: Member[]
   enableDetail?: boolean
-  externalLoading?: boolean
+  isLoading?: boolean
   /** 수강생: 기수 옵션 및 조회 시 API refetch 콜백 */
   studentCohortOptions?: DropdownOption[]
   onStudentSearch?: (filters: StudentSearchFilters) => void
@@ -58,7 +58,7 @@ export default function ManagementPage({
   listVariant,
   listData,
   enableDetail = true,
-  externalLoading,
+  isLoading,
   studentCohortOptions = listVariant === 'student'
     ? STUDENT_COHORT_OPTIONS
     : undefined,
@@ -82,22 +82,10 @@ export default function ManagementPage({
   const [editDetail, setEditDetail] = useState<MemberDetail | null>(null)
   const [memberList, setMemberList] = useState(listData)
   const showToast = useToastStore((state) => state.showToast)
-  const [internalLoading, setInternalLoading] = useState(
-    externalLoading === undefined
-  )
 
   useEffect(() => {
     setMemberList(listData)
   }, [listData])
-
-  useEffect(() => {
-    if (externalLoading !== undefined) return
-    const timer = setTimeout(() => setInternalLoading(false), 500)
-    return () => clearTimeout(timer)
-  }, [externalLoading])
-
-  const isLoading =
-    externalLoading !== undefined ? externalLoading : internalLoading
 
   const handleSearch = () => {
     setRole(roleInput ?? 'ALL')

--- a/src/pages/member-management/StudentManagementPage.tsx
+++ b/src/pages/member-management/StudentManagementPage.tsx
@@ -27,7 +27,7 @@ export function StudentManagementPage() {
       listVariant="student"
       listData={members}
       enableDetail={false}
-      externalLoading={isLoading}
+      isLoading={isLoading}
       onStudentSearch={handleStudentSearch}
     />
   )


### PR DESCRIPTION
## ✨ PR 개요
테스트로 500ms를 동안 로딩을 보여주었던 로직을 제거 후 실제 데이터 get하는 동안 로딩 상태로 띄우게 변경
 
## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #212 

## 🧩 작업 내용 (주요 변경사항)
- api 요청 훅에서 받아오는 isLoading값을 받아오게 기존 로직을 삭제 후 적용

## 💬 리뷰 포인트
externalLoading -> isLoading으로 변경하였습니다


## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
