### PR TITLE
feat: 배포 내역 관리 페이지와 회원 탈퇴 관리 페이지 수정 (#211)

### DIFF
--- a/src/api/deployment.ts
+++ b/src/api/deployment.ts
@@ -17,8 +17,8 @@ export const deploymentApi = {
       { params }
     ),
 
-  updateStatus: (id: number, is_active: boolean) =>
-    apiClient.patch(API_PATHS.DEPLOYMENT.STATUS(id), { is_active }),
+  updateStatus: (id: number, status: string) =>
+    apiClient.patch(API_PATHS.DEPLOYMENT.STATUS(id), { status }),
 
   delete: (id: number) => apiClient.delete(API_PATHS.DEPLOYMENT.DETAIL(id)),
 }

--- a/src/components/member-management/MemberWithdrawalDetailModal.tsx
+++ b/src/components/member-management/MemberWithdrawalDetailModal.tsx
@@ -7,7 +7,6 @@ import {
   type MemberStatus,
 } from '@/components/common'
 import type { MemberWithdrawalDetailType } from '@/types'
-import memberImg from '@/assets/MemberImg.jpeg'
 import {
   TableWrap,
   TableRow,
@@ -16,8 +15,7 @@ import {
   ProfileImageCell,
   DEFAULT_TABLE_COLUMNS,
 } from './MemberDetailTable'
-
-const DEFAULT_MEMBER_IMAGE_URL = memberImg
+import { formatDate } from '@/utils'
 
 type MemberWithdrawalDetailModalProps = {
   open: boolean
@@ -63,9 +61,7 @@ export function MemberWithdrawalDetailModal({
               <TableWrap rows={4} columns={DEFAULT_TABLE_COLUMNS}>
                 <TableRow>
                   <ProfileImageCell
-                    imageUrl={
-                      user.profile_image_url ?? DEFAULT_MEMBER_IMAGE_URL
-                    }
+                    imageUrl={user.profile_img_url}
                     alt={`${user.nickname} 프로필`}
                   />
                   <ThCell>ID</ThCell>
@@ -73,21 +69,27 @@ export function MemberWithdrawalDetailModal({
                 </TableRow>
                 <TableRow>
                   <ThCell>이름</ThCell>
-                  <TdCell>{user.name}</TdCell>
+                  <TdCell>{user.name || '-'}</TdCell>
                   <ThCell>성별</ThCell>
-                  <TdCell>{user.gender || '-'}</TdCell>
+                  <TdCell>
+                    {user.gender === 'MALE'
+                      ? '남'
+                      : user.gender === 'FEMALE'
+                        ? '여'
+                        : '미설정'}
+                  </TdCell>
                 </TableRow>
                 <TableRow>
                   <ThCell>닉네임</ThCell>
                   <TdCell>{user.nickname}</TdCell>
                   <ThCell>생년월일</ThCell>
-                  <TdCell>{user.birth_date}</TdCell>
+                  <TdCell>{user.birth_date || '-'}</TdCell>
                 </TableRow>
                 <TableRow>
                   <ThCell>이메일</ThCell>
                   <TdCell>{user.email}</TdCell>
                   <ThCell>연락처</ThCell>
-                  <TdCell>{user.phone}</TdCell>
+                  <TdCell>{user.phone || '-'}</TdCell>
                 </TableRow>
               </TableWrap>
             </section>
@@ -98,19 +100,23 @@ export function MemberWithdrawalDetailModal({
                   <ThCell>담당/수강 과정</ThCell>
                   <TdCell colSpan={2}>
                     {detail.assigned_courses.map((c, i) => (
-                      <div key={i}>{c.course_name}</div>
+                      <div key={i}>{c.course?.name}</div>
                     ))}
                   </TdCell>
                   <ThCell>기수</ThCell>
                   <TdCell colSpan={1}>
-                    {detail.assigned_courses.map((c, i) => (
-                      <div key={i}>{c.cohort ? `${c.cohort}기` : ''}</div>
-                    ))}
+                    <div className="flex flex-col gap-1">
+                      {detail.assigned_courses.length > 0
+                        ? detail.assigned_courses.map((c, i) => (
+                            <div key={i}>{c.cohort?.number}기</div>
+                          ))
+                        : '-'}
+                    </div>
                   </TdCell>
                 </TableRow>
                 <TableRow>
                   <ThCell>가입일</ThCell>
-                  <TdCell colSpan={4}>{user.joined_at}</TdCell>
+                  <TdCell colSpan={4}>{formatDate(user.created_at)}</TdCell>
                 </TableRow>
                 <TableRow>
                   <ThCell>권한</ThCell>
@@ -136,9 +142,11 @@ export function MemberWithdrawalDetailModal({
                 </TableRow>
                 <TableRow>
                   <ThCell>탈퇴 요청 일시</ThCell>
-                  <TdCell colSpan={2}>{detail.withdrawn_at}</TdCell>
+                  <TdCell colSpan={2}>{formatDate(detail.withdrawn_at)}</TdCell>
                   <ThCell>삭제 예정 일시</ThCell>
-                  <TdCell colSpan={1}>{detail.due_date}</TdCell>
+                  <TdCell colSpan={1}>
+                    {detail.due_date ? formatDate(detail.due_date) : '-'}
+                  </TdCell>
                 </TableRow>
                 <TableRow>
                   <ThCell>탈퇴 사유</ThCell>

--- a/src/components/table/ExamDeploymentList.tsx
+++ b/src/components/table/ExamDeploymentList.tsx
@@ -37,32 +37,35 @@ export function ExamDeploymentList({
         title: '제목',
         className: 'flex-1 min-w-[200px]',
         cell: (item) => (
-          <TitleCell title={item.title} onClick={() => onItemClick(item)} />
+          <TitleCell
+            title={item.exam?.title}
+            onClick={() => onItemClick(item)}
+          />
         ),
       },
       {
         key: 'subject',
         title: '과목명',
         size: 'lg',
-        cell: (item) => item.subject_name,
+        cell: (item) => item.subject?.name,
       },
       {
         key: 'course',
         title: '과정 | 기수',
         className: 'flex-1 min-w-[200px]',
-        cell: (item) => `${item.course_name} ${item.cohort}기`,
+        cell: (item) => `${item.cohort?.display} ${item.cohort?.number}기`,
       },
       {
         key: 'count',
         title: '응시 수',
         size: 'md',
-        cell: (item) => item.applicant_count,
+        cell: (item) => item.submit_count,
       },
       {
         key: 'avg',
         title: '평균',
         size: 'md',
-        cell: (item) => item.average_score,
+        cell: (item) => Math.floor(item.avg_score),
       },
       {
         key: 'date',
@@ -74,12 +77,17 @@ export function ExamDeploymentList({
         key: 'status',
         title: '배포 활성 상태',
         size: 'lg',
-        cell: (item) => (
-          <Switch
-            checked={item.is_active}
-            onChange={() => onToggleStatus(item.id, item.is_active)}
-          />
-        ),
+        cell: (item) => {
+          const isActive = item.status === 'activated'
+          return (
+            <Switch
+              checked={isActive}
+              onChange={() => {
+                onToggleStatus(item.id, !isActive)
+              }}
+            />
+          )
+        },
       },
     ],
     [onToggleStatus, onItemClick]

--- a/src/components/table/MemberWithdrawalList.tsx
+++ b/src/components/table/MemberWithdrawalList.tsx
@@ -7,6 +7,7 @@ import {
 import { DataTable, type Column } from '@/components/table/data-table/DataTable'
 import type { MemberWithdrawalItemType } from '@/types'
 import { NameCell } from './MemberList'
+import { formatDateTime } from '@/utils'
 
 type MemberWithdrawalListProps = {
   data: MemberWithdrawalItemType[]
@@ -76,7 +77,7 @@ export function MemberWithdrawalList({
         key: 'withdrawn_at',
         title: '탈퇴 일시',
         size: 'xl',
-        cell: (item) => item.withdrawn_at,
+        cell: (item) => formatDateTime(item.withdrawn_at),
       },
     ],
     [onItemClick]

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -11,10 +11,10 @@ export const API_PATHS = {
     LOGOUT: '/api/v1/accounts/logout/',
   },
   DEPLOYMENT: {
-    LIST: '/api/v1/admin/exams/deployments/',
-    DETAIL: (id: number | string) => `/api/v1/admin/exams/deployments/${id}/`,
+    LIST: '/api/v1/admin/exams/deployments',
+    DETAIL: (id: number | string) => `/api/v1/admin/exams/deployments/${id}`,
     STATUS: (id: number | string) =>
-      `/api/v1/admin/exams/deployments/${id}/status/`,
+      `/api/v1/admin/exams/deployments/${id}/status`,
   },
   EXAM: {
     LIST: '/api/v1/admin/exams',

--- a/src/hooks/useExamDeployment.ts
+++ b/src/hooks/useExamDeployment.ts
@@ -52,17 +52,21 @@ export function useExamDeployment() {
     fetchList()
   }, [fetchList])
 
-  const handleToggleStatus = async (id: number, currentStatus: boolean) => {
+  const handleToggleStatus = async (id: number, currentIsActive: boolean) => {
+    const nextStatus = currentIsActive ? 'activated' : 'deactivated'
+
     try {
-      await deploymentApi.updateStatus(id, !currentStatus)
+      await deploymentApi.updateStatus(id, nextStatus)
       setData((prev) =>
         prev.map((item) =>
-          item.id === id ? { ...item, is_active: !currentStatus } : item
+          item.id === id
+            ? { ...item, status: nextStatus as 'activated' | 'deactivated' }
+            : item
         )
       )
       showToast({
         variant: 'success',
-        message: `배포 상태가 ${!currentStatus ? '활성화' : '비활성화'} 되었습니다.`,
+        message: `배포 상태가 ${nextStatus === 'activated' ? '활성화' : '비활성화'} 되었습니다.`,
       })
     } catch (error) {
       showToast({ variant: 'error', message: '상태 변경에 실패했습니다.' })

--- a/src/types/exam.ts
+++ b/src/types/exam.ts
@@ -18,14 +18,24 @@ export interface ExamListResponse {
 
 export interface ExamDeploymentItemType {
   id: number
-  title: string
-  subject_name: string
-  course_name: string
-  cohort: number
-  applicant_count: number
-  average_score: number
+  submit_count: number
+  avg_score: number
+  status: 'activated' | 'deactivated'
+  exam: {
+    id: number
+    title: string
+    thumbnail_img_url: string
+  }
+  subject: {
+    id: number
+    name: string
+  }
+  cohort: {
+    id: number
+    number: number
+    display: string
+  }
   created_at: string
-  is_active: boolean
 }
 
 export interface PaginatedDeploymentResponse<T> {

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -112,11 +112,11 @@ export type WithdrawalUserInfoType = {
   email: string
   phone: string
   birth_date: string
-  gender: string
+  gender: 'MALE' | 'FEMALE' | null
   role: string
-  joined_at: string
-  profile_image_url?: string
   status: string
+  profile_img_url: string | undefined
+  created_at: string
 }
 
 export type MemberWithdrawalItemType = {
@@ -131,8 +131,19 @@ export type MemberWithdrawalDetailType = {
   id: number
   user: WithdrawalUserInfoType
   assigned_courses: {
-    course_name: string
-    cohort?: number
+    course: {
+      id: number
+      name: string
+      tag: string
+    }
+    cohort: {
+      id: number
+      number: number
+      status: string
+      status_display: string
+      start_date: string
+      end_date: string
+    }
   }[]
   reason: string
   reason_display: string


### PR DESCRIPTION
## ✨ PR 개요
<!-- 어떤 작업을 했는지 간략히 요약 -->
배포 내역 관리 페이지와 회원 탈퇴 관리 페이지 수정

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #211 

## 🧩 작업 내용 (주요 변경사항)
- API에 맞춰 타입 수정
- `API_PATHS`에서 API 주소 수정
- API 연결

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
- 회원 탈퇴 관리
<img width="1917" height="940" alt="image" src="https://github.com/user-attachments/assets/b30568f5-dc5e-4514-bf7e-5692c3f4b45a" />

- 배포 내역 관리
https://github.com/user-attachments/assets/dd138a3c-8529-40e8-b884-f3d8f9c3681e

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
