### PR TITLE
feat: 쪽지시험 배포 생성 추가 (#215)

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -11,10 +11,14 @@ export const API_PATHS = {
     LOGOUT: '/api/v1/accounts/logout/',
   },
   DEPLOYMENT: {
-    LIST: '/api/v1/admin/exams/deployments',
-    DETAIL: (id: number | string) => `/api/v1/admin/exams/deployments/${id}`,
+    LIST: '/api/v1/admin/exams/deployments/',
+    DETAIL: (id: number | string) => `/api/v1/admin/exams/deployments/${id}/`,
     STATUS: (id: number | string) =>
-      `/api/v1/admin/exams/deployments/${id}/status`,
+      `/api/v1/admin/exams/deployments/${id}/status/`,
+    CREATE: '/api/v1/admin/exams/deployments',
+  },
+  COHORT: {
+    LIST: (courseId: number | string) => `/api/v1/${courseId}/cohorts`,
   },
   EXAM: {
     LIST: '/api/v1/admin/exams',

--- a/src/constants/time-options.ts
+++ b/src/constants/time-options.ts
@@ -3,6 +3,5 @@ export const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
     .toString()
     .padStart(2, '0')
   const minute = i % 2 === 0 ? '00' : '30'
-  const time = `${hour} : ${minute}`
-  return { value: time, label: time }
+  return { value: `${hour}:${minute}`, label: `${hour} : ${minute}` }
 })

--- a/src/pages/exam-page/exam-list/ExamListPage.tsx
+++ b/src/pages/exam-page/exam-list/ExamListPage.tsx
@@ -171,15 +171,17 @@ export function ExamListPage() {
               onChange={setPage}
               containerClassName="flex justify-center"
             />
-            <div className="flex justify-end">
-              <Button
-                variant="primary"
-                onClick={() => setIsModalOpen(true)}
-                className="h-[36px] w-[55px] rounded-sm text-sm font-normal"
-              >
-                생성
-              </Button>
-            </div>
+            {!isLoading && (
+              <div className="flex justify-end">
+                <Button
+                  variant="primary"
+                  onClick={() => setIsModalOpen(true)}
+                  className="h-[36px] w-[55px] rounded-sm text-sm font-normal"
+                >
+                  생성
+                </Button>
+              </div>
+            )}
           </div>
         }
       >

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -7,7 +7,9 @@ export const getTodayDate = (): string => {
 // 현재 시간을 HH : mm 형식으로 반환, 30분 단위로 올림/내림 처리.
 export const getNearest30MinTime = (): string => {
   const now = new Date()
-  return `${String(now.getHours()).padStart(2, '0')} : ${now.getMinutes() < 30 ? '00' : '30'}`
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = now.getMinutes() < 30 ? '00' : '30'
+  return `${hours}:${minutes}`
 }
 
 // 날짜(YYYY-MM-DD)와 시간(HH : mm)을 백엔드 규격(YYYY-MM-DD HH:mm:ss)으로 변환.


### PR DESCRIPTION
## ✨ PR 개요
쪽지시험 배포 생성 로직을 배포 버튼에 적용하였습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #215 

## 🧩 작업 내용 (주요 변경사항)
- 쪽지시험 조회에 각 시험별 배포 버튼 클릭 시 모달에 입력을 받을수 있음 -> 빈칸이 있거나 시작 시간 끝나는 시각이 같으면 경고 모달 
- 배포 생성 성공 시 성공 toast 출력

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/2d5cc21b-185e-4271-b81b-62713618eeb4



## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
