### PR TITLE
style: 수강생 등록신청, 회원 탈퇴 관리 스타일 통일 (#213)

### DIFF
--- a/src/components/layout/MeberRegisterLayout.tsx
+++ b/src/components/layout/MeberRegisterLayout.tsx
@@ -6,16 +6,14 @@ type MemberManagementLayoutProps = {
   description?: string
   headerRight?: ReactNode
   toolbar?: ReactNode
-  footer?: ReactNode
   children: ReactNode
 }
 
-export function MemberManagementLayout({
+export function MemberRegisterLayout({
   title,
   description,
   headerRight,
   toolbar,
-  footer,
   children,
 }: MemberManagementLayoutProps) {
   return (
@@ -37,8 +35,6 @@ export function MemberManagementLayout({
         {toolbar && <div className="mb-6 flex items-end gap-4">{toolbar}</div>}
 
         <div className="w-full">{children}</div>
-
-        {footer && <div className="flex w-full">{footer}</div>}
       </div>
     </AdminContainer>
   )

--- a/src/components/table/MemberWithdrawalList.tsx
+++ b/src/components/table/MemberWithdrawalList.tsx
@@ -84,12 +84,10 @@ export function MemberWithdrawalList({
   )
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="flex-1 overflow-hidden">
-        <DataTable data={data} columns={columns} />
-      </div>
+    <div className="w-full">
+      <DataTable data={data} columns={columns} />
 
-      <div className="mt-8 flex justify-center">
+      <div className="flex justify-center">
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}

--- a/src/components/table/StudentRegistrationList.tsx
+++ b/src/components/table/StudentRegistrationList.tsx
@@ -19,10 +19,7 @@ type StudentRegistrationListProps = {
 
 export function StudentRegistrationList({
   data,
-  currentPage,
-  totalPages,
   selectedIds,
-  onPageChange,
   onToggleOne,
   onToggleAll,
 }: StudentRegistrationListProps) {
@@ -96,14 +93,6 @@ export function StudentRegistrationList({
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="flex-1 overflow-hidden">
         <DataTable data={data} columns={columns} />
-      </div>
-
-      <div className="mt-8 flex justify-center">
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onChange={onPageChange}
-        />
       </div>
     </div>
   )

--- a/src/components/table/StudentRegistrationList.tsx
+++ b/src/components/table/StudentRegistrationList.tsx
@@ -1,18 +1,11 @@
 import { useMemo } from 'react'
-import {
-  CustomCheckbox,
-  MemberStatusBadge,
-  Pagination,
-} from '@/components/common'
+import { CustomCheckbox, MemberStatusBadge } from '@/components/common'
 import { DataTable, type Column } from '@/components/table/data-table/DataTable'
 import type { StudentRegistrationItemType } from '@/types'
 
 type StudentRegistrationListProps = {
   data: StudentRegistrationItemType[]
-  currentPage: number
-  totalPages: number
   selectedIds: number[]
-  onPageChange: (page: number) => void
   onToggleOne: (id: number) => void
   onToggleAll: () => void
 }

--- a/src/pages/member-management/ManagementPage.tsx
+++ b/src/pages/member-management/ManagementPage.tsx
@@ -37,8 +37,7 @@ type ManagementPageProps = {
   listVariant: 'member' | 'student'
   listData: Member[]
   enableDetail?: boolean
-  isLoading?: boolean
-  /** 수강생: 기수 옵션 및 조회 시 API refetch 콜백 */
+  isLoading: boolean
   studentCohortOptions?: DropdownOption[]
   onStudentSearch?: (filters: StudentSearchFilters) => void
 }

--- a/src/pages/member-management/MemberManagementPage.tsx
+++ b/src/pages/member-management/MemberManagementPage.tsx
@@ -12,7 +12,7 @@ export function MemberManagementPage() {
       title="회원관리"
       listVariant="member"
       listData={members}
-      externalLoading={isLoading}
+      isLoading={isLoading}
     />
   )
 }

--- a/src/pages/member-management/MemberWithdrawalPage.tsx
+++ b/src/pages/member-management/MemberWithdrawalPage.tsx
@@ -1,5 +1,5 @@
-import { Button, Dropdown, Input } from '@/components/common'
-import { AdminContainer } from '@/components/layout'
+import { Button, Dropdown, Input, TableSkeleton } from '@/components/common'
+import { MemberManagementLayout } from '@/components/layout'
 import { MemberWithdrawalDetailModal } from '@/components/member-management/MemberWithdrawalDetailModal'
 import { MemberWithdrawalList } from '@/components/table/MemberWithdrawalList'
 import { useMemberWithdrawal } from '@/hooks/useMemberWithdrawal'
@@ -30,9 +30,10 @@ export function MemberWithdrawalPage() {
 
   return (
     <>
-      <AdminContainer title="회원 탈퇴 관리">
-        <div className="flex h-full flex-col px-6">
-          <div className="mb-6 flex items-center gap-3">
+      <MemberManagementLayout
+        title="회원 탈퇴 관리"
+        toolbar={
+          <>
             <div className="w-48">
               <Dropdown
                 size="sm"
@@ -60,21 +61,23 @@ export function MemberWithdrawalPage() {
               onClick={applyFilters}
               disabled={isLoading}
             >
-              {isLoading ? '로딩 중...' : '조회'}
+              조회
             </Button>
-          </div>
-
-          <div className="relative flex flex-1 flex-col overflow-hidden">
-            <MemberWithdrawalList
-              data={data}
-              onItemClick={openDetail}
-              currentPage={filters.page}
-              totalCount={totalCount}
-              onPageChange={(page) => setFilters((p) => ({ ...p, page }))}
-            />
-          </div>
-        </div>
-      </AdminContainer>
+          </>
+        }
+      >
+        {isLoading ? (
+          <TableSkeleton rows={10} />
+        ) : (
+          <MemberWithdrawalList
+            data={data}
+            onItemClick={openDetail}
+            currentPage={filters.page}
+            totalCount={totalCount}
+            onPageChange={(page) => setFilters((p) => ({ ...p, page }))}
+          />
+        )}
+      </MemberManagementLayout>
       <MemberWithdrawalDetailModal
         open={isModalOpen}
         onClose={closeDetail}

--- a/src/pages/member-management/StudentRegistrationPage.tsx
+++ b/src/pages/member-management/StudentRegistrationPage.tsx
@@ -1,5 +1,12 @@
-import { AlertModal, Button, Dropdown, Input } from '@/components/common'
-import { AdminContainer } from '@/components/layout'
+import {
+  AlertModal,
+  Button,
+  Dropdown,
+  Input,
+  Pagination,
+  TableSkeleton,
+} from '@/components/common'
+import { MemberManagementLayout } from '@/components/layout'
 import { StudentRegistrationList } from '@/components/table/StudentRegistrationList'
 import { useStudentRegistration } from '@/hooks'
 import type { DropdownOption } from '@/types'
@@ -33,9 +40,10 @@ export function StudentRegistrationPage() {
 
   return (
     <>
-      <AdminContainer title="수강생 등록 신청">
-        <div className="flex h-full flex-col px-6">
-          <div className="mb-6 flex items-center gap-3">
+      <MemberManagementLayout
+        title="수강생 등록 신청"
+        toolbar={
+          <>
             <div className="w-48">
               <Dropdown
                 size="sm"
@@ -66,40 +74,53 @@ export function StudentRegistrationPage() {
               onClick={applyFilters}
               disabled={isLoading}
             >
-              {isLoading ? '조회 중...' : '조회'}
+              조회
             </Button>
-          </div>
-
-          <div className="relative flex flex-1 flex-col overflow-hidden">
-            <StudentRegistrationList
-              data={items}
+          </>
+        }
+        footer={
+          <div className="grid w-full grid-cols-3 items-center">
+            <div />
+            <Pagination
               currentPage={currentPage}
               totalPages={totalPages}
-              selectedIds={selectedIds}
-              onPageChange={setCurrentPage}
-              onToggleOne={toggleOne}
-              onToggleAll={toggleAll}
+              onChange={setCurrentPage}
             />
-
-            <div className="absolute right-0 bottom-0 flex gap-2">
-              <Button
-                variant="primary"
-                onClick={openApproveModal}
-                disabled={isActionLoading}
-              >
-                승인
-              </Button>
-              <Button
-                variant="danger"
-                onClick={openRejectModal}
-                disabled={isActionLoading}
-              >
-                반려
-              </Button>
-            </div>
+            {!isLoading && (
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="primary"
+                  onClick={openApproveModal}
+                  disabled={isActionLoading}
+                >
+                  승인
+                </Button>
+                <Button
+                  variant="danger"
+                  onClick={openRejectModal}
+                  disabled={isActionLoading}
+                >
+                  반려
+                </Button>
+              </div>
+            )}
           </div>
-        </div>
-      </AdminContainer>
+        }
+      >
+        {isLoading ? (
+          <TableSkeleton rows={10} />
+        ) : (
+          <StudentRegistrationList
+            data={items}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            selectedIds={selectedIds}
+            onPageChange={setCurrentPage}
+            onToggleOne={toggleOne}
+            onToggleAll={toggleAll}
+          />
+        )}
+      </MemberManagementLayout>
 
       <AlertModal
         isOpen={modalConfig.isOpen}

--- a/src/pages/member-management/StudentRegistrationPage.tsx
+++ b/src/pages/member-management/StudentRegistrationPage.tsx
@@ -112,10 +112,7 @@ export function StudentRegistrationPage() {
         ) : (
           <StudentRegistrationList
             data={items}
-            currentPage={currentPage}
-            totalPages={totalPages}
             selectedIds={selectedIds}
-            onPageChange={setCurrentPage}
             onToggleOne={toggleOne}
             onToggleAll={toggleAll}
           />


### PR DESCRIPTION
## ✨ PR 개요
회원관리 섹션에서 각 페이지를 담당하는 레이아웃들 중 수강생 등록신청 페이지와 회원 탈퇴 페이지의 스타일을 통일 + 에러 수정

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #213 

## 🧩 작업 내용 (주요 변경사항)
- 수강생 등록 신청 , 회원 탈퇴 관리 스타일 통일
- 빌드 에러 추가 수정


## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
